### PR TITLE
Add missing dependencies pyproject toml for simple agent notebook

### DIFF
--- a/use-case-examples/Simple Nemotron-3-Nano Usage Example/pyproject.toml
+++ b/use-case-examples/Simple Nemotron-3-Nano Usage Example/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "nemotron-3-nano-simple-usage-guide"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "ddgs>=9.9.3",
+    "duckduckgo-search>=8.1.1",
+    "jupyter>=1.1.1",
+    "langchain>=1.1.3",
+    "langchain-community>=0.4.1",
+    "langchain-nvidia-ai-endpoints>=1.0.0",
+    "langchain-openai>=1.1.1",
+    "langgraph>=1.0.4",
+]
+


### PR DESCRIPTION
Change adds the pyproject.toml that was missing in the Nemotron 3 Nano simple example notebook folder. 