### PR TITLE
Clarify distinction between recipes, cookbooks, and use-case examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ nemotron/
 └── use-case-examples/       Examples of leveraging Nemotron in agentic workflows
 ```
 
+### Which section should I use?
+
+| | **Training Recipes** | **Usage Cookbooks** | **Use Case Examples** |
+|---|---|---|---|
+| **Purpose** | Reproduce full training pipelines from raw data to model | Deploy and use trained models | Build end-to-end applications |
+| **Format** | Python packages with configs, scripts, and evaluation | Jupyter notebooks with step-by-step guides | Jupyter notebooks and scripts |
+| **When to use** | You want to train, fine-tune, or understand how a model was built | You have a model and want to deploy or run inference | You want to build an application (RAG, agents, tool use) |
+| **Location** | [`src/nemotron/recipes/`](./src/nemotron/recipes/) | [`usage-cookbook/`](./usage-cookbook/) | [`use-case-examples/`](./use-case-examples/) |
+
 ---
 
 ## What is Nemotron?


### PR DESCRIPTION
## Summary

Fixes #75

Adds a comparison table to the Repository Overview section that helps new users quickly understand the distinction between the three content types:

- **Training Recipes** - Reproduce full training pipelines (Python packages)
- **Usage Cookbooks** - Deploy and use trained models (Jupyter notebooks)
- **Use Case Examples** - Build end-to-end applications (RAG, agents, tool use)

The table covers purpose, format, when to use, and links to the directory.

## Test plan

- [ ] Verify the table renders correctly on GitHub
- [ ] Verify links to directories are valid

This contribution was developed with AI assistance (Claude Code).