### PR TITLE
Adds TRT-LLM Docker run of Nemotron Super 3 in DGX Spark

### DIFF
--- a/usage-cookbook/Nemotron-3-Super/AdvancedDeploymentGuide/README.md
+++ b/usage-cookbook/Nemotron-3-Super/AdvancedDeploymentGuide/README.md
@@ -260,6 +260,7 @@ If you want to run this directly with Docker and Hugging Face model weights, use
 > TensorRT-LLM uses Git LFS. Install it before cloning.
 
 ```bash
+# Building TRT-LLM container
 sudo apt-get update && sudo apt-get -y install git git-lfs
 git lfs install
 
@@ -269,12 +270,14 @@ git checkout b79f4c7700e164045f647aaaac9c30eace3b9ab5
 git submodule update --init --recursive
 git lfs pull
 
+# Downloading the model
 hf download nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
 ```
 
 Mount the downloaded checkpoint cache and `config/y.yaml` into the container:
 
 ```bash
+# Start serving model
 HF_MODEL_CACHE_DIR="${HF_HOME:-$HOME/.cache/huggingface}/hub/models--nvidia--NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
 
 docker run -ti --rm \


### PR DESCRIPTION
## Summary
Modified `usage-cookbook/Nemotron-3-Super/AdvancedDeploymentGuide/README.md` demonstrating inference with Nemotron 3 Super NVFP4 in DGX Spark via TensorRT-LLM Docker container.

What's covered:

* Adds instruction on how to build TRT-LLM and the right commit.
* How to create `y.yaml` for DGX Spark
* How to start the container and load the model 

### Research & Context
No AI assistant used for the development of this PR.