### PR TITLE
Fix CLI crash by removing import of non-existent super3 data module

### DIFF
--- a/src/nemotron/cli/commands/super3/_typer_group.py
+++ b/src/nemotron/cli/commands/super3/_typer_group.py
@@ -23,7 +23,6 @@ Design: LLM-Native Recipe Architecture
 
 from __future__ import annotations
 
-from nemotron.cli.commands.super3.data import data_app
 from nemotron.cli.commands.super3.eval import META as EVAL_META
 from nemotron.cli.commands.super3.eval import eval as eval_cmd
 from nemotron.cli.commands.super3.model import model_app
@@ -39,9 +38,6 @@ super3_app = RecipeTyper(
     no_args_is_help=True,
     rich_markup_mode="rich",
 )
-
-# Register data subgroup
-super3_app.add_typer(data_app, name="data")
 
 # Register model subgroup
 super3_app.add_typer(model_app, name="model")


### PR DESCRIPTION
The super3 `_typer_group.py` imported `data_app` from `nemotron.cli.commands.super3.data`, which was never created, causing a `ModuleNotFoundError` on every CLI invocation. 

```
(nemotron) sthan@sthan-mlt Nemotron % nemotron -h                       
Traceback (most recent call last):
  File "/Users/sthan/workspace/Nemotron/.venv/bin/nemotron", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/sthan/workspace/Nemotron/src/nemotron/__main__.py", line 31, in main
    from nemotron.cli.bin.nemotron import main as typer_main
  File "/Users/sthan/workspace/Nemotron/src/nemotron/cli/bin/nemotron.py", line 100, in <module>
    _register_groups()
  File "/Users/sthan/workspace/Nemotron/src/nemotron/cli/bin/nemotron.py", line 89, in _register_groups
    from nemotron.cli.commands.super3 import super3_app
  File "/Users/sthan/workspace/Nemotron/src/nemotron/cli/commands/super3/__init__.py", line 20, in <module>
    from nemotron.cli.commands.super3._typer_group import super3_app
  File "/Users/sthan/workspace/Nemotron/src/nemotron/cli/commands/super3/_typer_group.py", line 26, in <module>
    from nemotron.cli.commands.super3.data import data_app
ModuleNotFoundError: No module named 'nemotron.cli.commands.super3.data'
```

This fix is to remove import of non-existent super3 data module