### PR TITLE
fix(super3): add missing data subcommand package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,9 @@ outputs/
 logs/
 checkpoints/
 data/
-!src/nemotron/cli/nano3/data/
-!src/nemotron/cli/embed/data/
+!src/nemotron/cli/commands/nano3/data/
+!src/nemotron/cli/commands/super3/data/
+!src/nemotron/cli/commands/embed/data/
 workspace/
 wandb/
 .nemotron/

--- a/src/nemotron/cli/commands/super3/data/__init__.py
+++ b/src/nemotron/cli/commands/super3/data/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data command group for super3."""
+
+from nemotron.cli.commands.super3.data._typer_group import data_app
+
+__all__ = ["data_app"]

--- a/src/nemotron/cli/commands/super3/data/_typer_group.py
+++ b/src/nemotron/cli/commands/super3/data/_typer_group.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data command group for super3."""
+
+from __future__ import annotations
+
+import typer
+
+from nemotron.cli.commands.super3.data.import_ import import_app
+from nemotron.cli.commands.super3.data.prep import prep_app
+
+# Create data app
+data_app = typer.Typer(
+    name="data",
+    help="Data curation and preparation commands",
+    no_args_is_help=True,
+)
+
+# Register prep subgroup
+data_app.add_typer(prep_app, name="prep")
+
+# Register import subgroup
+data_app.add_typer(import_app, name="import")

--- a/src/nemotron/cli/commands/super3/data/import_/__init__.py
+++ b/src/nemotron/cli/commands/super3/data/import_/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data import command group for super3."""
+
+from nemotron.cli.commands.super3.data.import_._typer_group import import_app
+
+__all__ = ["import_app"]

--- a/src/nemotron/cli/commands/super3/data/import_/_typer_group.py
+++ b/src/nemotron/cli/commands/super3/data/import_/_typer_group.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data import Typer group for super3."""
+
+from __future__ import annotations
+
+import typer
+
+from nemotron.cli.commands.super3.data.import_.pretrain import pretrain
+from nemotron.cli.commands.super3.data.import_.rl import rl
+from nemotron.cli.commands.super3.data.import_.sft import sft
+
+# Create import app
+import_app = typer.Typer(
+    name="import",
+    help="Import data as W&B artifacts",
+    no_args_is_help=True,
+)
+
+# Register commands
+import_app.command(name="pretrain")(pretrain)
+import_app.command(name="sft")(sft)
+import_app.command(name="rl")(rl)

--- a/src/nemotron/cli/commands/super3/data/import_/pretrain.py
+++ b/src/nemotron/cli/commands/super3/data/import_/pretrain.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import pretrain data as W&B artifact."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nemotron.kit.artifact import DataBlendsArtifact
+from nemo_runspec.env import get_wandb_config
+from nemotron.kit.wandb_kit import WandbConfig, init_wandb_if_configured
+
+
+def pretrain(
+    data_path: Path = typer.Argument(..., help="Path to blend.json file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Custom artifact name"),
+    project: str | None = typer.Option(
+        None, "--project", "-p", help="W&B project (overrides env.toml)"
+    ),
+    entity: str | None = typer.Option(
+        None, "--entity", "-e", help="W&B entity (overrides env.toml)"
+    ),
+) -> None:
+    """Import pretrain data (blend.json) as a W&B artifact.
+
+    Examples:
+        nemotron super3 data import pretrain /path/to/blend.json
+        nemotron super3 data import pretrain /path/to/blend.json --project my-project
+    """
+    # Resolve data path
+    data_path = data_path.resolve()
+    if not data_path.exists():
+        typer.echo(f"Error: Data path does not exist: {data_path}", err=True)
+        raise typer.Exit(1)
+
+    # Build W&B config from env.toml with CLI overrides
+    env_wandb = get_wandb_config()
+    wandb_project = project or (env_wandb.project if env_wandb else None)
+    wandb_entity = entity or (env_wandb.entity if env_wandb else None)
+
+    if not wandb_project:
+        typer.echo("Error: W&B project required. Set in env.toml or use --project", err=True)
+        raise typer.Exit(1)
+
+    wandb_config = WandbConfig(project=wandb_project, entity=wandb_entity)
+
+    # Initialize W&B
+    init_wandb_if_configured(wandb_config, job_type="data-import", tags=["pretrain", "import"])
+
+    # Create artifact with minimal required fields
+    artifact_name = name or "super3/pretrain/data"
+    artifact = DataBlendsArtifact(
+        path=data_path,
+        total_tokens=0,
+        total_sequences=0,
+        name=artifact_name,
+    )
+
+    # Save and register with W&B
+    artifact.save()
+
+    typer.echo(f"Imported pretrain data from {data_path}")
+    typer.echo(f"Artifact: {artifact_name}")

--- a/src/nemotron/cli/commands/super3/data/import_/rl.py
+++ b/src/nemotron/cli/commands/super3/data/import_/rl.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import RL data as W&B artifact."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nemotron.kit.artifact import SplitJsonlDataArtifact
+from nemo_runspec.env import get_wandb_config
+from nemotron.kit.wandb_kit import WandbConfig, init_wandb_if_configured
+
+
+def rl(
+    data_dir: Path = typer.Argument(..., help="Path to data directory containing manifest.json"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Custom artifact name"),
+    project: str | None = typer.Option(
+        None, "--project", "-p", help="W&B project (overrides env.toml)"
+    ),
+    entity: str | None = typer.Option(
+        None, "--entity", "-e", help="W&B entity (overrides env.toml)"
+    ),
+) -> None:
+    """Import RL data directory as a W&B artifact.
+
+    Examples:
+        nemotron super3 data import rl /path/to/data_dir
+        nemotron super3 data import rl /path/to/data_dir --project my-project
+    """
+    # Resolve data directory
+    data_dir = data_dir.resolve()
+    if not data_dir.exists():
+        typer.echo(f"Error: Data directory does not exist: {data_dir}", err=True)
+        raise typer.Exit(1)
+
+    if not data_dir.is_dir():
+        typer.echo(f"Error: Path is not a directory: {data_dir}", err=True)
+        raise typer.Exit(1)
+
+    # Look for manifest.json in directory
+    manifest_path = data_dir / "manifest.json"
+    if not manifest_path.exists():
+        typer.echo(f"Error: No manifest.json found in directory: {data_dir}", err=True)
+        raise typer.Exit(1)
+
+    # Build W&B config from env.toml with CLI overrides
+    env_wandb = get_wandb_config()
+    wandb_project = project or (env_wandb.project if env_wandb else None)
+    wandb_entity = entity or (env_wandb.entity if env_wandb else None)
+
+    if not wandb_project:
+        typer.echo("Error: W&B project required. Set in env.toml or use --project", err=True)
+        raise typer.Exit(1)
+
+    wandb_config = WandbConfig(project=wandb_project, entity=wandb_entity)
+
+    # Initialize W&B
+    init_wandb_if_configured(wandb_config, job_type="data-import", tags=["rl", "import"])
+
+    # Create artifact with minimal required fields
+    artifact_name = name or "super3/rl/data"
+    artifact = SplitJsonlDataArtifact(
+        path=manifest_path,
+        total_sequences=0,
+        name=artifact_name,
+    )
+
+    # Save and register with W&B
+    artifact.save()
+
+    typer.echo(f"Imported RL data from {data_dir}")
+    typer.echo(f"Artifact: {artifact_name}")

--- a/src/nemotron/cli/commands/super3/data/import_/sft.py
+++ b/src/nemotron/cli/commands/super3/data/import_/sft.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import SFT data as W&B artifact."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nemotron.kit.artifact import DataBlendsArtifact
+from nemo_runspec.env import get_wandb_config
+from nemotron.kit.wandb_kit import WandbConfig, init_wandb_if_configured
+
+
+def sft(
+    data_dir: Path = typer.Argument(..., help="Path to data directory containing blend.json"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Custom artifact name"),
+    project: str | None = typer.Option(
+        None, "--project", "-p", help="W&B project (overrides env.toml)"
+    ),
+    entity: str | None = typer.Option(
+        None, "--entity", "-e", help="W&B entity (overrides env.toml)"
+    ),
+) -> None:
+    """Import SFT data directory as a W&B artifact.
+
+    Examples:
+        nemotron super3 data import sft /path/to/data_dir
+        nemotron super3 data import sft /path/to/data_dir --project my-project
+    """
+    # Resolve data directory
+    data_dir = data_dir.resolve()
+    if not data_dir.exists():
+        typer.echo(f"Error: Data directory does not exist: {data_dir}", err=True)
+        raise typer.Exit(1)
+
+    if not data_dir.is_dir():
+        typer.echo(f"Error: Path is not a directory: {data_dir}", err=True)
+        raise typer.Exit(1)
+
+    # Look for blend.json in directory
+    blend_path = data_dir / "blend.json"
+    if not blend_path.exists():
+        typer.echo(f"Error: No blend.json found in directory: {data_dir}", err=True)
+        raise typer.Exit(1)
+
+    # Build W&B config from env.toml with CLI overrides
+    env_wandb = get_wandb_config()
+    wandb_project = project or (env_wandb.project if env_wandb else None)
+    wandb_entity = entity or (env_wandb.entity if env_wandb else None)
+
+    if not wandb_project:
+        typer.echo("Error: W&B project required. Set in env.toml or use --project", err=True)
+        raise typer.Exit(1)
+
+    wandb_config = WandbConfig(project=wandb_project, entity=wandb_entity)
+
+    # Initialize W&B
+    init_wandb_if_configured(wandb_config, job_type="data-import", tags=["sft", "import"])
+
+    # Create artifact with minimal required fields
+    artifact_name = name or "super3/sft/data"
+    artifact = DataBlendsArtifact(
+        path=blend_path,
+        total_tokens=0,
+        total_sequences=0,
+        name=artifact_name,
+    )
+
+    # Save and register with W&B
+    artifact.save()
+
+    typer.echo(f"Imported SFT data from {data_dir}")
+    typer.echo(f"Artifact: {artifact_name}")

--- a/src/nemotron/cli/commands/super3/data/prep/__init__.py
+++ b/src/nemotron/cli/commands/super3/data/prep/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data prep command group for super3."""
+
+from nemotron.cli.commands.super3.data.prep._typer_group import prep_app
+
+__all__ = ["prep_app"]

--- a/src/nemotron/cli/commands/super3/data/prep/_typer_group.py
+++ b/src/nemotron/cli/commands/super3/data/prep/_typer_group.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data prep command group for super3.
+
+Design: LLM-Native Recipe Architecture
+- Uses RecipeTyper for standardized command registration
+- Each command module has visible execution logic
+"""
+
+from __future__ import annotations
+
+from nemotron.cli.commands.super3.data.prep.pretrain import META as PRETRAIN_META, pretrain
+from nemotron.cli.commands.super3.data.prep.rl import META as RL_META, rl
+from nemotron.cli.commands.super3.data.prep.sft import META as SFT_META, sft
+from nemo_runspec.recipe_typer import RecipeTyper
+
+# Create prep app using RecipeTyper
+prep_app = RecipeTyper(
+    name="prep",
+    help="Prepare data for training stages",
+    no_args_is_help=True,
+    rich_markup_mode="rich",
+)
+
+# =============================================================================
+# Register Data Prep Commands
+#
+# All data prep commands use Ray + code packager + xenna.
+# Execution logic is visible in each command module.
+# =============================================================================
+
+prep_app.add_recipe_command(pretrain, meta=PRETRAIN_META)
+prep_app.add_recipe_command(sft, meta=SFT_META)
+prep_app.add_recipe_command(rl, meta=RL_META)

--- a/src/nemotron/cli/commands/super3/data/prep/pretrain.py
+++ b/src/nemotron/cli/commands/super3/data/prep/pretrain.py
@@ -1,0 +1,350 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pretrain data preparation command.
+
+This module defines the `data prep pretrain` command with **visible
+execution logic**. Data prep uses Ray + CodePackager + xenna run_command.
+
+Key differences from training commands:
+- Uses packager="code" (full codebase rsync, no path rewriting)
+- Uses Ray for distributed execution
+- Uses custom run_command for xenna dependency
+
+Design: LLM-Native Recipe Architecture
+- Execution logic visible and modifiable
+- Fork this file to change how data prep jobs are submitted
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+
+import typer
+
+from nemo_runspec import parse as parse_runspec
+from nemo_runspec.config import (
+    build_job_config,
+    extract_train_config,
+    generate_job_dir,
+    parse_config,
+    save_configs,
+)
+from nemo_runspec.display import display_job_config, display_job_submission
+from nemo_runspec.env import parse_env
+from nemo_runspec.execution import (
+    build_env_vars,
+    clone_git_repos_via_tunnel,
+    execute_local,
+    get_startup_commands,
+    prepend_startup_to_cmd,
+)
+from nemo_runspec.squash import ensure_squashed_image
+from nemo_runspec.recipe_config import RecipeConfig, parse_recipe_config
+from nemo_runspec.recipe_typer import RecipeMeta
+
+# =============================================================================
+# Recipe Metadata (read from [tool.runspec] in script)
+# =============================================================================
+
+SCRIPT_PATH = "src/nemotron/recipes/super3/stage0_pretrain/data_prep.py"
+SPEC = parse_runspec(SCRIPT_PATH)
+
+# Implementation details — setup commands stay here
+SETUP_COMMANDS = [
+    "find . -type d -name __pycache__ -delete 2>/dev/null || true",
+    "uv sync --reinstall-package nemotron",
+]
+
+# For help panels
+META = RecipeMeta(
+    name=SPEC.name,
+    script_path=SCRIPT_PATH,
+    config_dir=str(SPEC.config_dir),
+    default_config=SPEC.config.default,
+    input_artifacts={"data": "Raw text data source"},
+    output_artifacts={"data": "Tokenized pretrain data (bin/idx format)"},
+)
+
+
+# =============================================================================
+# Execution Logic - VISIBLE
+# =============================================================================
+
+
+def _execute_data_prep_pretrain(cfg: RecipeConfig):
+    """Execute pretrain data prep with Ray via nemo-run.
+
+    Data prep uses the "code" packager which rsyncs the full codebase
+    and does NOT rewrite paths. The run_command uses xenna extras.
+    """
+    # =========================================================================
+    # 1. Parse configuration
+    # =========================================================================
+    train_config = parse_config(cfg.ctx, SPEC.config_dir, SPEC.config.default)
+    env = parse_env(cfg.ctx)
+
+    # Build full job config with provenance
+    job_config = build_job_config(
+        train_config,
+        cfg.ctx,
+        SPEC.name,
+        SCRIPT_PATH,
+        cfg.argv,
+        env_profile=env,
+    )
+
+    # For "code" packager, do NOT show remote paths (they resolve at runtime)
+    display_job_config(job_config, for_remote=False)
+
+    # Handle dry-run mode
+    if cfg.dry_run:
+        return
+
+    # =========================================================================
+    # 2. Save configs and prepare execution
+    # =========================================================================
+    job_dir = generate_job_dir(SPEC.name)
+    # For code packager, don't rewrite paths (for_remote=False)
+    train_config_for_script = extract_train_config(job_config, for_remote=False)
+    job_path, train_path = save_configs(job_config, train_config_for_script, job_dir)
+
+    # Get env config from job_config.run.env (merged YAML + env.toml)
+    env_for_executor = job_config.run.env if hasattr(job_config.run, "env") else None
+
+    env_vars = build_env_vars(job_config, env_for_executor)
+
+    # Display job submission summary
+    display_job_submission(job_path, train_path, env_vars, cfg.mode, artifacts=job_config.get("artifacts"))
+
+    # Get startup commands from env config
+    startup_commands = get_startup_commands(env_for_executor)
+
+    # =========================================================================
+    # 3. Execute based on mode
+    # =========================================================================
+    if cfg.mode == "local":
+        execute_local(
+            SCRIPT_PATH,
+            train_path,
+            cfg.passthrough,
+            torchrun=False,  # Ray handles distribution
+            env_vars=env_vars,
+            startup_commands=startup_commands,
+        )
+    else:
+        # Remote execution via Ray with code packager
+        _execute_ray_code_packager(
+            train_path=train_path,
+            job_dir=job_dir,
+            job_config=job_config,
+            env=env_for_executor,
+            passthrough=cfg.passthrough,
+            attached=cfg.attached,
+            env_vars=env_vars,
+            startup_commands=startup_commands,
+            force_squash=cfg.force_squash,
+        )
+
+
+def _execute_ray_code_packager(
+    train_path: Path,
+    job_dir: Path,
+    job_config,
+    env,
+    passthrough: list[str],
+    attached: bool,
+    env_vars: dict[str, str],
+    startup_commands: list[str] | None,
+    force_squash: bool,
+):
+    """Execute via Ray with code packager.
+
+    The code packager rsyncs the full codebase, so paths are NOT rewritten.
+    The script runs from the rsynced location where ${oc.env:PWD} resolves
+    correctly at runtime.
+
+    FORK POINT: Replace this function for different Ray/data-prep submission.
+    """
+    try:
+        import nemo_run as run
+        from nemo_run.run.ray.job import RayJob
+    except ImportError:
+        typer.echo("Error: nemo-run is required for --run/--batch execution", err=True)
+        typer.echo("Install with: pip install nemo-run", err=True)
+        raise typer.Exit(1)
+
+    from nemo_runspec.packaging import CodePackager
+    from nemo_runspec.run import (
+        patch_nemo_run_ray_template_for_cpu,
+        patch_nemo_run_rsync_accept_new_host_keys,
+    )
+
+    # Apply nemo-run patches
+    patch_nemo_run_rsync_accept_new_host_keys()
+    patch_nemo_run_ray_template_for_cpu()
+
+    # Helper for accessing env config (OmegaConf or dict)
+    def _get(key: str, default=None):
+        if env is None:
+            return default
+        return env.get(key, default) if hasattr(env, "get") else getattr(env, key, default)
+
+    # Build executor
+    tunnel = None
+    remote_job_dir = _get("remote_job_dir")
+    if _get("tunnel") == "ssh":
+        tunnel = run.SSHTunnel(
+            host=_get("host", "localhost"),
+            user=_get("user"),
+            job_dir=remote_job_dir,
+        )
+
+    # Build packager - code packager rsyncs full codebase
+    packager = CodePackager(
+        script_path=SCRIPT_PATH,
+        train_path=str(train_path),
+        exclude_dirs=("usage-cookbook", "use-case-examples"),
+    )
+
+    container_image = _get("container_image") or _get("container") or SPEC.image
+
+    if container_image and tunnel and remote_job_dir:
+        tunnel.connect()
+        container_image = ensure_squashed_image(
+            tunnel, container_image, remote_job_dir, env, force=force_squash
+        )
+
+    git_mounts = []
+    if tunnel and remote_job_dir:
+        tunnel.connect()
+        git_mounts = clone_git_repos_via_tunnel(tunnel, remote_job_dir)
+
+    if attached:
+        partition = _get("run_partition") or _get("partition")
+    else:
+        partition = _get("batch_partition") or _get("partition")
+
+    raw_mounts = list(_get("mounts") or [])
+    mounts = [m for m in raw_mounts if not m.startswith("__auto_mount__:")]
+    mounts.extend(git_mounts)
+    mounts.append("/lustre:/lustre")
+
+    if remote_job_dir:
+        ray_temp_path = f"{remote_job_dir}/ray_temp"
+        mounts.append(f"{ray_temp_path}:/ray-cluster")
+        if tunnel:
+            tunnel.run(f"mkdir -p {ray_temp_path}", hide=True)
+
+    executor = run.SlurmExecutor(
+        account=_get("account"),
+        partition=partition,
+        nodes=_get("nodes", 1),
+        ntasks_per_node=_get("ntasks_per_node", 1),
+        gpus_per_node=_get("gpus_per_node"),
+        cpus_per_task=_get("cpus_per_task"),
+        time=_get("time", "04:00:00"),
+        container_image=container_image,
+        container_mounts=mounts,
+        tunnel=tunnel,
+        packager=packager,
+        mem=_get("mem"),
+        env_vars=env_vars,
+        launcher=None,
+    )
+
+    # Ray job setup
+    recipe_name = SPEC.name.replace("/", "-")
+    job_name = f"{recipe_name}_{int(time.time())}"
+    ray_job = RayJob(name=job_name, executor=executor)
+
+    # Copy train.yaml to repo root
+    repo_config = Path.cwd() / "config.yaml"
+    shutil.copy2(train_path, repo_config)
+
+    # Setup commands (implementation detail, defined at module level)
+    setup_commands = list(SETUP_COMMANDS)
+
+    # Get actual script path (code packager doesn't rename to main.py)
+    remote_script = SCRIPT_PATH
+
+    # Build command with run_command template
+    effective_run_command = _get("run_command", SPEC.run.cmd)
+
+    cmd = effective_run_command.format(script=remote_script, config="config.yaml")
+
+    if passthrough:
+        cmd += " " + " ".join(passthrough)
+
+    if startup_commands:
+        cmd = prepend_startup_to_cmd(startup_commands, cmd)
+
+    # Runtime env for Ray workers
+    runtime_env: dict = {"env_vars": dict(env_vars)}
+
+    import tempfile
+    import yaml as pyyaml
+
+    runtime_env_yaml = None
+    if runtime_env["env_vars"]:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            pyyaml.dump(runtime_env, f)
+            runtime_env_yaml = f.name
+
+    # Start Ray job
+    ray_job.start(
+        command=cmd,
+        workdir=str(Path.cwd()) + "/",
+        pre_ray_start_commands=setup_commands,
+        runtime_env_yaml=runtime_env_yaml,
+    )
+
+    # Copy config.yaml to remote
+    remote_code_dir = f"{executor.tunnel.job_dir}/{job_name}/code"
+    executor.tunnel.put(str(repo_config), f"{remote_code_dir}/config.yaml")
+
+    # Recover job_id if needed
+    if ray_job.backend.job_id is None:
+        try:
+            status = ray_job.backend.status(display=False)
+            if status and status.get("job_id"):
+                ray_job.backend.job_id = status["job_id"]
+        except Exception:
+            pass
+
+    # Attach to logs if requested
+    if attached:
+        try:
+            ray_job.logs(follow=True, timeout=600)
+        except KeyboardInterrupt:
+            job_id = ray_job.backend.job_id
+            typer.echo(f"\n[info] Detaching. Job {job_id} continues running.")
+            raise typer.Exit(0)
+
+
+# =============================================================================
+# CLI Entry Point
+# =============================================================================
+
+
+def pretrain(ctx: typer.Context) -> None:
+    """Tokenize data for pretraining (bin/idx format).
+
+    This command prepares tokenized data for the Super3 pretraining stage.
+    Uses Ray for distributed processing with the xenna data pipeline.
+    """
+    cfg = parse_recipe_config(ctx)
+    _execute_data_prep_pretrain(cfg)

--- a/src/nemotron/cli/commands/super3/data/prep/rl.py
+++ b/src/nemotron/cli/commands/super3/data/prep/rl.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RL data preparation command for super3.
+
+Design: LLM-Native Recipe Architecture
+- Execution logic visible and modifiable
+- Fork this file to change how data prep jobs are submitted
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+
+import typer
+
+from nemo_runspec import parse as parse_runspec
+from nemo_runspec.config import (
+    build_job_config,
+    extract_train_config,
+    generate_job_dir,
+    parse_config,
+    save_configs,
+)
+from nemo_runspec.display import display_job_config, display_job_submission
+from nemo_runspec.env import parse_env
+from nemo_runspec.execution import (
+    build_env_vars,
+    clone_git_repos_via_tunnel,
+    execute_local,
+    get_startup_commands,
+    prepend_startup_to_cmd,
+)
+from nemo_runspec.squash import ensure_squashed_image
+from nemo_runspec.recipe_config import RecipeConfig, parse_recipe_config
+from nemo_runspec.recipe_typer import RecipeMeta
+
+SCRIPT_PATH = "src/nemotron/recipes/super3/stage2_rl/data_prep.py"
+SPEC = parse_runspec(SCRIPT_PATH)
+
+SETUP_COMMANDS = [
+    "find . -type d -name __pycache__ -delete 2>/dev/null || true",
+    "uv sync --reinstall-package nemotron",
+]
+
+META = RecipeMeta(
+    name=SPEC.name,
+    script_path=SCRIPT_PATH,
+    config_dir=str(SPEC.config_dir),
+    default_config=SPEC.config.default,
+    input_artifacts={"data": "Prompt data (JSONL/HuggingFace dataset)"},
+    output_artifacts={"data": "RL prompts (JSONL chat format)"},
+)
+
+
+def _execute_data_prep_rl(cfg: RecipeConfig):
+    """Execute RL data prep with Ray via nemo-run."""
+    train_config = parse_config(cfg.ctx, SPEC.config_dir, SPEC.config.default)
+    env = parse_env(cfg.ctx)
+
+    job_config = build_job_config(
+        train_config, cfg.ctx, SPEC.name, SCRIPT_PATH, cfg.argv, env_profile=env,
+    )
+    display_job_config(job_config, for_remote=False)
+
+    if cfg.dry_run:
+        return
+
+    job_dir = generate_job_dir(SPEC.name)
+    train_config_for_script = extract_train_config(job_config, for_remote=False)
+    job_path, train_path = save_configs(job_config, train_config_for_script, job_dir)
+
+    env_for_executor = job_config.run.env if hasattr(job_config.run, "env") else None
+    env_vars = build_env_vars(job_config, env_for_executor)
+    display_job_submission(job_path, train_path, env_vars, cfg.mode, artifacts=job_config.get("artifacts"))
+    startup_commands = get_startup_commands(env_for_executor)
+
+    if cfg.mode == "local":
+        execute_local(SCRIPT_PATH, train_path, cfg.passthrough, torchrun=False,
+                      env_vars=env_vars, startup_commands=startup_commands)
+    else:
+        _execute_ray_code_packager(
+            train_path=train_path, job_dir=job_dir, job_config=job_config,
+            env=env_for_executor, passthrough=cfg.passthrough, attached=cfg.attached,
+            env_vars=env_vars, startup_commands=startup_commands, force_squash=cfg.force_squash,
+        )
+
+
+def _execute_ray_code_packager(
+    train_path: Path, job_dir: Path, job_config, env,
+    passthrough: list[str], attached: bool, env_vars: dict[str, str],
+    startup_commands: list[str] | None, force_squash: bool,
+):
+    """Execute via Ray with code packager. FORK POINT for alternative backends."""
+    try:
+        import nemo_run as run
+        from nemo_run.run.ray.job import RayJob
+    except ImportError:
+        typer.echo("Error: nemo-run is required for --run/--batch execution", err=True)
+        typer.echo("Install with: pip install nemo-run", err=True)
+        raise typer.Exit(1)
+
+    from nemo_runspec.packaging import CodePackager
+    from nemo_runspec.run import (
+        patch_nemo_run_ray_template_for_cpu,
+        patch_nemo_run_rsync_accept_new_host_keys,
+    )
+
+    patch_nemo_run_rsync_accept_new_host_keys()
+    patch_nemo_run_ray_template_for_cpu()
+
+    def _get(key: str, default=None):
+        if env is None:
+            return default
+        return env.get(key, default) if hasattr(env, "get") else getattr(env, key, default)
+
+    tunnel = None
+    remote_job_dir = _get("remote_job_dir")
+    if _get("tunnel") == "ssh":
+        tunnel = run.SSHTunnel(host=_get("host", "localhost"), user=_get("user"), job_dir=remote_job_dir)
+
+    packager = CodePackager(
+        script_path=SCRIPT_PATH, train_path=str(train_path),
+        exclude_dirs=("usage-cookbook", "use-case-examples"),
+    )
+
+    container_image = _get("container_image") or _get("container") or SPEC.image
+    if container_image and tunnel and remote_job_dir:
+        tunnel.connect()
+        container_image = ensure_squashed_image(tunnel, container_image, remote_job_dir, env, force=force_squash)
+
+    git_mounts = []
+    if tunnel and remote_job_dir:
+        tunnel.connect()
+        git_mounts = clone_git_repos_via_tunnel(tunnel, remote_job_dir)
+
+    partition = _get("run_partition") if attached else _get("batch_partition")
+    partition = partition or _get("partition")
+
+    raw_mounts = list(_get("mounts") or [])
+    mounts = [m for m in raw_mounts if not m.startswith("__auto_mount__:")]
+    mounts.extend(git_mounts)
+    mounts.append("/lustre:/lustre")
+
+    if remote_job_dir:
+        ray_temp_path = f"{remote_job_dir}/ray_temp"
+        mounts.append(f"{ray_temp_path}:/ray-cluster")
+        if tunnel:
+            tunnel.run(f"mkdir -p {ray_temp_path}", hide=True)
+
+    executor = run.SlurmExecutor(
+        account=_get("account"), partition=partition,
+        nodes=_get("nodes", 1), ntasks_per_node=_get("ntasks_per_node", 1),
+        gpus_per_node=_get("gpus_per_node"), cpus_per_task=_get("cpus_per_task"),
+        time=_get("time", "04:00:00"), container_image=container_image,
+        container_mounts=mounts, tunnel=tunnel, packager=packager,
+        mem=_get("mem"), env_vars=env_vars, launcher=None,
+    )
+
+    recipe_name = SPEC.name.replace("/", "-")
+    job_name = f"{recipe_name}_{int(time.time())}"
+    ray_job = RayJob(name=job_name, executor=executor)
+
+    repo_config = Path.cwd() / "config.yaml"
+    shutil.copy2(train_path, repo_config)
+
+    effective_run_command = _get("run_command", SPEC.run.cmd)
+    cmd = effective_run_command.format(script=SCRIPT_PATH, config="config.yaml")
+    if passthrough:
+        cmd += " " + " ".join(passthrough)
+    if startup_commands:
+        cmd = prepend_startup_to_cmd(startup_commands, cmd)
+
+    runtime_env: dict = {"env_vars": dict(env_vars)}
+
+    import tempfile
+    import yaml as pyyaml
+
+    runtime_env_yaml = None
+    if runtime_env["env_vars"]:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            pyyaml.dump(runtime_env, f)
+            runtime_env_yaml = f.name
+
+    ray_job.start(command=cmd, workdir=str(Path.cwd()) + "/",
+                  pre_ray_start_commands=list(SETUP_COMMANDS), runtime_env_yaml=runtime_env_yaml)
+
+    remote_code_dir = f"{executor.tunnel.job_dir}/{job_name}/code"
+    executor.tunnel.put(str(repo_config), f"{remote_code_dir}/config.yaml")
+
+    if ray_job.backend.job_id is None:
+        try:
+            status = ray_job.backend.status(display=False)
+            if status and status.get("job_id"):
+                ray_job.backend.job_id = status["job_id"]
+        except Exception:
+            pass
+
+    if attached:
+        try:
+            ray_job.logs(follow=True, timeout=600)
+        except KeyboardInterrupt:
+            typer.echo(f"\n[info] Detaching. Job {ray_job.backend.job_id} continues running.")
+            raise typer.Exit(0)
+
+
+def rl(ctx: typer.Context) -> None:
+    """Prepare data for RL (JSONL chat format with HF placeholder resolution).
+
+    Uses Ray for distributed processing with the xenna data pipeline.
+    """
+    cfg = parse_recipe_config(ctx)
+    _execute_data_prep_rl(cfg)

--- a/src/nemotron/cli/commands/super3/data/prep/sft.py
+++ b/src/nemotron/cli/commands/super3/data/prep/sft.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SFT data preparation command for super3.
+
+Design: LLM-Native Recipe Architecture
+- Execution logic visible and modifiable
+- Fork this file to change how data prep jobs are submitted
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+
+import typer
+
+from nemo_runspec import parse as parse_runspec
+from nemo_runspec.config import (
+    build_job_config,
+    extract_train_config,
+    generate_job_dir,
+    parse_config,
+    save_configs,
+)
+from nemo_runspec.display import display_job_config, display_job_submission
+from nemo_runspec.env import parse_env
+from nemo_runspec.execution import (
+    build_env_vars,
+    clone_git_repos_via_tunnel,
+    execute_local,
+    get_startup_commands,
+    prepend_startup_to_cmd,
+)
+from nemo_runspec.squash import ensure_squashed_image
+from nemo_runspec.recipe_config import RecipeConfig, parse_recipe_config
+from nemo_runspec.recipe_typer import RecipeMeta
+
+SCRIPT_PATH = "src/nemotron/recipes/super3/stage1_sft/data_prep.py"
+SPEC = parse_runspec(SCRIPT_PATH)
+
+SETUP_COMMANDS = [
+    "find . -type d -name __pycache__ -delete 2>/dev/null || true",
+    "uv sync --reinstall-package nemotron",
+]
+
+META = RecipeMeta(
+    name=SPEC.name,
+    script_path=SCRIPT_PATH,
+    config_dir=str(SPEC.config_dir),
+    default_config=SPEC.config.default,
+    input_artifacts={"data": "Conversation data (JSONL/Parquet)"},
+    output_artifacts={"data": "Packed SFT data (.npy format)"},
+)
+
+
+def _execute_data_prep_sft(cfg: RecipeConfig):
+    """Execute SFT data prep with Ray via nemo-run."""
+    train_config = parse_config(cfg.ctx, SPEC.config_dir, SPEC.config.default)
+    env = parse_env(cfg.ctx)
+
+    job_config = build_job_config(
+        train_config, cfg.ctx, SPEC.name, SCRIPT_PATH, cfg.argv, env_profile=env,
+    )
+    display_job_config(job_config, for_remote=False)
+
+    if cfg.dry_run:
+        return
+
+    job_dir = generate_job_dir(SPEC.name)
+    train_config_for_script = extract_train_config(job_config, for_remote=False)
+    job_path, train_path = save_configs(job_config, train_config_for_script, job_dir)
+
+    env_for_executor = job_config.run.env if hasattr(job_config.run, "env") else None
+    env_vars = build_env_vars(job_config, env_for_executor)
+    display_job_submission(job_path, train_path, env_vars, cfg.mode, artifacts=job_config.get("artifacts"))
+    startup_commands = get_startup_commands(env_for_executor)
+
+    if cfg.mode == "local":
+        execute_local(SCRIPT_PATH, train_path, cfg.passthrough, torchrun=False,
+                      env_vars=env_vars, startup_commands=startup_commands)
+    else:
+        _execute_ray_code_packager(
+            train_path=train_path, job_dir=job_dir, job_config=job_config,
+            env=env_for_executor, passthrough=cfg.passthrough, attached=cfg.attached,
+            env_vars=env_vars, startup_commands=startup_commands, force_squash=cfg.force_squash,
+        )
+
+
+def _execute_ray_code_packager(
+    train_path: Path, job_dir: Path, job_config, env,
+    passthrough: list[str], attached: bool, env_vars: dict[str, str],
+    startup_commands: list[str] | None, force_squash: bool,
+):
+    """Execute via Ray with code packager. FORK POINT for alternative backends."""
+    try:
+        import nemo_run as run
+        from nemo_run.run.ray.job import RayJob
+    except ImportError:
+        typer.echo("Error: nemo-run is required for --run/--batch execution", err=True)
+        typer.echo("Install with: pip install nemo-run", err=True)
+        raise typer.Exit(1)
+
+    from nemo_runspec.packaging import CodePackager
+    from nemo_runspec.run import (
+        patch_nemo_run_ray_template_for_cpu,
+        patch_nemo_run_rsync_accept_new_host_keys,
+    )
+
+    patch_nemo_run_rsync_accept_new_host_keys()
+    patch_nemo_run_ray_template_for_cpu()
+
+    def _get(key: str, default=None):
+        if env is None:
+            return default
+        return env.get(key, default) if hasattr(env, "get") else getattr(env, key, default)
+
+    tunnel = None
+    remote_job_dir = _get("remote_job_dir")
+    if _get("tunnel") == "ssh":
+        tunnel = run.SSHTunnel(host=_get("host", "localhost"), user=_get("user"), job_dir=remote_job_dir)
+
+    packager = CodePackager(
+        script_path=SCRIPT_PATH, train_path=str(train_path),
+        exclude_dirs=("usage-cookbook", "use-case-examples"),
+    )
+
+    container_image = _get("container_image") or _get("container") or SPEC.image
+    if container_image and tunnel and remote_job_dir:
+        tunnel.connect()
+        container_image = ensure_squashed_image(tunnel, container_image, remote_job_dir, env, force=force_squash)
+
+    git_mounts = []
+    if tunnel and remote_job_dir:
+        tunnel.connect()
+        git_mounts = clone_git_repos_via_tunnel(tunnel, remote_job_dir)
+
+    partition = _get("run_partition") if attached else _get("batch_partition")
+    partition = partition or _get("partition")
+
+    raw_mounts = list(_get("mounts") or [])
+    mounts = [m for m in raw_mounts if not m.startswith("__auto_mount__:")]
+    mounts.extend(git_mounts)
+    mounts.append("/lustre:/lustre")
+
+    if remote_job_dir:
+        ray_temp_path = f"{remote_job_dir}/ray_temp"
+        mounts.append(f"{ray_temp_path}:/ray-cluster")
+        if tunnel:
+            tunnel.run(f"mkdir -p {ray_temp_path}", hide=True)
+
+    executor = run.SlurmExecutor(
+        account=_get("account"), partition=partition,
+        nodes=_get("nodes", 1), ntasks_per_node=_get("ntasks_per_node", 1),
+        gpus_per_node=_get("gpus_per_node"), cpus_per_task=_get("cpus_per_task"),
+        time=_get("time", "04:00:00"), container_image=container_image,
+        container_mounts=mounts, tunnel=tunnel, packager=packager,
+        mem=_get("mem"), env_vars=env_vars, launcher=None,
+    )
+
+    recipe_name = SPEC.name.replace("/", "-")
+    job_name = f"{recipe_name}_{int(time.time())}"
+    ray_job = RayJob(name=job_name, executor=executor)
+
+    repo_config = Path.cwd() / "config.yaml"
+    shutil.copy2(train_path, repo_config)
+
+    effective_run_command = _get("run_command", SPEC.run.cmd)
+    cmd = effective_run_command.format(script=SCRIPT_PATH, config="config.yaml")
+    if passthrough:
+        cmd += " " + " ".join(passthrough)
+    if startup_commands:
+        cmd = prepend_startup_to_cmd(startup_commands, cmd)
+
+    runtime_env: dict = {"env_vars": dict(env_vars)}
+
+    import tempfile
+    import yaml as pyyaml
+
+    runtime_env_yaml = None
+    if runtime_env["env_vars"]:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            pyyaml.dump(runtime_env, f)
+            runtime_env_yaml = f.name
+
+    ray_job.start(command=cmd, workdir=str(Path.cwd()) + "/",
+                  pre_ray_start_commands=list(SETUP_COMMANDS), runtime_env_yaml=runtime_env_yaml)
+
+    remote_code_dir = f"{executor.tunnel.job_dir}/{job_name}/code"
+    executor.tunnel.put(str(repo_config), f"{remote_code_dir}/config.yaml")
+
+    if ray_job.backend.job_id is None:
+        try:
+            status = ray_job.backend.status(display=False)
+            if status and status.get("job_id"):
+                ray_job.backend.job_id = status["job_id"]
+        except Exception:
+            pass
+
+    if attached:
+        try:
+            ray_job.logs(follow=True, timeout=600)
+        except KeyboardInterrupt:
+            typer.echo(f"\n[info] Detaching. Job {ray_job.backend.job_id} continues running.")
+            raise typer.Exit(0)
+
+
+def sft(ctx: typer.Context) -> None:
+    """Prepare data for SFT (packed .npy format).
+
+    Uses Ray for distributed processing with the xenna data pipeline.
+    """
+    cfg = parse_recipe_config(ctx)
+    _execute_data_prep_sft(cfg)


### PR DESCRIPTION
## Summary

- Adds the missing `data` subpackage for the `super3` CLI command, which was imported in `_typer_group.py` but never created, causing an immediate `ModuleNotFoundError` on any `nemotron super3` invocation
- Implements `nemotron super3 data prep pretrain/sft/rl` — Ray-based distributed data preparation wired to the existing `stage0_pretrain`, `stage1_sft`, and `stage2_rl` recipe scripts
- Implements `nemotron super3 data import pretrain/sft/rl` — W&B artifact import commands mirroring the `nano3` pattern
- Fixes `.gitignore` negation paths that referenced `cli/nano3/data/` instead of the correct `cli/commands/nano3/data/`, and adds the missing `super3/data` exception

## Test plan

- [ ] `nemotron super3 --help` lists `data` subcommand without import error
- [ ] `nemotron super3 data --help` shows `prep` and `import` subgroups
- [ ] `nemotron super3 data prep pretrain --help` shows config/run options
- [ ] `nemotron super3 data import pretrain --help` shows artifact import options
- [ ] Confirm `.gitignore` no longer excludes files under `src/nemotron/cli/commands/super3/data/`

Closes #100