### PR TITLE
Fix embedding SDG dedup compatibility.

### DIFF
--- a/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/pyproject.toml
+++ b/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pandas>=2.0.0",
     "numpy>=1.24.0",
     "nltk>=3.9.2",
-    "data-designer>=0.5.0",
+    "data-designer>=0.5.3",
 ]
 
 [project.optional-dependencies]

--- a/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/deduplication.py
+++ b/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/deduplication.py
@@ -40,14 +40,16 @@ class DDRetrievalDedup(ColumnGeneratorCellByCell[DDRetrievalDedupConfig]):
     def _embed(self, text: str) -> list[float]:
         """Calculate an embedding of the text
         """
-        response = self.embedder._router.embedding(
-            input=text,
-            model=self.embedder.model_name,
+        # Data Designer's public embedding API moved behind ModelFacade methods.
+        # Use the facade directly rather than reaching into removed private attrs
+        # like `_router`, which breaks across library versions.
+        response = self.embedder.generate_text_embeddings(
+            [text],
             encoding_format="float",
-            extra_body=self.embedder._model_config.inference_parameters.
-            extra_body)
+            extra_body=self.embedder._model_config.inference_parameters.extra_body,
+        )
 
-        return response.data[0]["embedding"]
+        return response[0]
 
     def dedupe_qa_pairs(self, embeddings: list[list[float]]) -> list[int]:
         """Run a semantic dedupe of the qa pairs.


### PR DESCRIPTION
Use Data Designer's public embedding facade API so Stage 0 dedup continues working after the private router interface change.