### PR TITLE
chore: Refactor use of directories as docs content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ main.py
 
 # Documentation build
 docs/_build/
+docs/usage-cookbook/
+docs/use-case-examples/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Building the Documentation
+
+The authoritative recipe for building the documentation is what runs in CI, the
+_build_docs job in <https://github.com/NVIDIA-NeMo/FW-CI-templates>.
+
+1. Install documentation dependencies with [uv](https://docs.astral.sh/uv/):
+
+   ```bash
+   uv sync --group docs
+   ```
+
+1. Build HTML from the `docs/` directory:
+
+   ```bash
+   cd docs
+   sphinx-build --fail-on-warning --builder html . _build/html
+   ```
+
+Open `docs/_build/html/index.html` in a browser to preview the output.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,44 +21,6 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 import os
-import shutil
-from pathlib import Path
-
-
-# -- Preprocessing: Replace symlinks with actual copies ---------------------
-def replace_symlinks_with_copies():
-    """Replace symlinked directories with actual copies at build time (CI only)."""
-    # Only run in CI environments to avoid disrupting local development
-    # GitHub Actions (and most CI systems) set CI=true
-    if not os.environ.get("CI"):
-        print("Skipping symlink replacement (not in CI environment)")
-        return
-
-    docs_dir = Path(__file__).parent
-    symlinks = ["usage-cookbook", "use-case-examples"]
-
-    for symlink_name in symlinks:
-        symlink_path = docs_dir / symlink_name
-
-        # Check if it's a symlink
-        if symlink_path.is_symlink():
-            # Resolve the target
-            target = symlink_path.resolve()
-
-            if target.exists():
-                print(f"Replacing symlink {symlink_name} with actual copy from {target}")
-                # Remove the symlink
-                symlink_path.unlink()
-                # Copy the actual directory
-                shutil.copytree(target, symlink_path)
-            else:
-                print(f"Warning: Symlink target {target} does not exist")
-
-
-# Run preprocessing
-print("Running docs preprocessing...")
-replace_symlinks_with_copies()
-print("Preprocessing complete!")
 
 
 project = "Nemotron"
@@ -79,10 +41,16 @@ extensions = [
     "sphinx_copybutton",  # For copy button in code blocks
     "sphinx_design",  # For grid cards and other design elements
     "sphinxcontrib.mermaid",  # For mermaid diagrams
+    "sphinxcontrib.copydirs",
+]
+
+copydirs_additional_dirs = [
+    "../usage-cookbook",
+    "../use-case-examples",
 ]
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["README.md", "_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for MyST Parser (Markdown) --------------------------------------
 # MyST Parser settings

--- a/docs/usage-cookbook
+++ b/docs/usage-cookbook
@@ -1,1 +1,0 @@
-../usage-cookbook

--- a/docs/use-case-examples
+++ b/docs/use-case-examples
@@ -1,1 +1,0 @@
-../use-case-examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,4 +134,5 @@ docs = [
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.6.0",
     "sphinxcontrib-mermaid",
+    "sphinxcontrib-copydirs @ git+https://github.com/mikemckiernan/sphinxcontrib-copydirs@v0.4.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2321,6 +2321,7 @@ docs = [
     { name = "sphinx-autodoc2" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
+    { name = "sphinxcontrib-copydirs" },
     { name = "sphinxcontrib-mermaid" },
 ]
 run = [
@@ -2377,6 +2378,7 @@ docs = [
     { name = "sphinx-autodoc2", specifier = ">=0.5.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.0" },
+    { name = "sphinxcontrib-copydirs", git = "https://github.com/mikemckiernan/sphinxcontrib-copydirs?rev=v0.4.1" },
     { name = "sphinxcontrib-mermaid" },
 ]
 run = [{ name = "nemo-run", specifier = ">=0.4.0" }]
@@ -4478,6 +4480,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-copydirs"
+version = "0.4.1"
+source = { git = "https://github.com/mikemckiernan/sphinxcontrib-copydirs?rev=v0.4.1#d6d8cf33e8052d22fb7593093d19f190d555ab0d" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]


### PR DESCRIPTION
My engineering team might be contributing to this repo in the near future, so in advance, I wanted to make a few suggestions.

I dusted off an old extension that sidesteps the use of the file system links.  They are a slight objection for Windows users.

I can share the diffs--minimal and mostly about links--if you like, but you've been replacing the links with `shutil.copydir` in CI already, so you might already know what those diffs look like.

PTAL and let me know if there's anything you'd like changed.