### PR TITLE
Fix retriever SDG dedup plugin circular import

### DIFF
--- a/src/nemotron/recipes/embed/stage0_sdg/pyproject.toml
+++ b/src/nemotron/recipes/embed/stage0_sdg/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 
 [tool.uv.sources]
 # Point to vendored retriever-sdg package
-retriever-sdg = { path = "vendor/retriever-sdg" }
+retriever-sdg = { path = "vendor/retriever-sdg", editable = true }
 
 [tool.uv.extra-build-dependencies]
 # Build dependencies for vendored packages

--- a/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/deduplication.py
+++ b/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/deduplication.py
@@ -7,8 +7,13 @@ from typing import Literal
 import numpy as np
 
 from data_designer.config.base import SingleColumnConfig
-from data_designer.engine.column_generators.generators.base import ColumnGeneratorCellByCell
 from data_designer.plugins import Plugin, PluginType
+
+__all__ = [
+    "DDRetrievalDedupConfig",
+    "DDRetrievalDedup",
+    "dd_retrieval_dedup_plugin",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +35,19 @@ class DDRetrievalDedupConfig(SingleColumnConfig):
         return []
 
 
-class DDRetrievalDedup(ColumnGeneratorCellByCell[DDRetrievalDedupConfig]):
+# Data Designer may re-enter this module during plugin discovery while the
+# generator base class import is still in progress. Publish the plugin after
+# the config exists so the re-entrant import can resolve it cleanly.
+dd_retrieval_dedup_plugin = Plugin(
+    impl_qualified_name="retriever_sdg.deduplication.DDRetrievalDedup",
+    config_qualified_name="retriever_sdg.deduplication.DDRetrievalDedupConfig",
+    plugin_type=PluginType.COLUMN_GENERATOR,
+)
 
+from data_designer.engine.column_generators.generators.base import ColumnGeneratorCellByCell  # noqa: E402
+
+
+class DDRetrievalDedup(ColumnGeneratorCellByCell[DDRetrievalDedupConfig]):
     @property
     def embedder(self):
         return self.resource_provider.model_registry.get_model(
@@ -123,10 +139,3 @@ class DDRetrievalDedup(ColumnGeneratorCellByCell[DDRetrievalDedupConfig]):
         retained_qa_pairs = [qa_pairs[i] for i in retained_qa_pair_indexes]
 
         return data | {self.config.name: retained_qa_pairs}
-
-
-dd_retrieval_dedup_plugin = Plugin(
-    impl_qualified_name="retriever_sdg.deduplication.DDRetrievalDedup",
-    config_qualified_name="retriever_sdg.deduplication.DDRetrievalDedupConfig",
-    plugin_type=PluginType.COLUMN_GENERATOR,
-)


### PR DESCRIPTION
Fixes the error printed in embed receipe sdg stage:

```
Failed to load plugin from entry point 'data-designer-retrieval-dedup': partially initialized module 'retriever_sdg.deduplication' has no attribute 'dd_retrieval_dedup_plugin' (most likely due to a circular import)
```

This error didn't prevent the stage from running sucessfully, but is a confusing error to show up in the logs.

- Avoid a circular import in `retriever_sdg.deduplication` by publishing the `dd_retrieval_dedup_plugin` before importing `ColumnGeneratorCellByCell`, so Data Designer's re-entrant plugin discovery can resolve the plugin while the generator base class import is still in progress.
- Add `__all__` to make the public surface explicit.

## Test plan
- [x] `nemotron` embedding SDG dedup stage loads without ImportError on plugin discovery
- [x] Run the retriever SDG dedup step end-to-end against a small sample