### PR TITLE
fix(super3): point SFT HF conversion at Nemotron-3-Super base

### DIFF
--- a/docs/nemotron/super3/README.md
+++ b/docs/nemotron/super3/README.md
@@ -64,10 +64,10 @@ $ uv run nemotron super3 eval --run YOUR-CLUSTER
 
 - **Tech Report**: Nemotron 3 Super Technical Report (coming soon)
 - **Model Weights**:
-  - NVIDIA-Nemotron-3-Super-120B-A12B-BF16 (Post-trained model, coming soon)
-  - NVIDIA-Nemotron-3-Super-120B-A12B-FP8 (FP8 quantized, coming soon)
-  - NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 (NVFP4 quantized, coming soon)
-  - NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16 (Base model, coming soon)
+  - [NVIDIA-Nemotron-3-Super-120B-A12B-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16) (Post-trained model)
+  - [NVIDIA-Nemotron-3-Super-120B-A12B-FP8](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8) (FP8 quantized)
+  - [NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4) (NVFP4 quantized)
+  - [NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16) (Base model)
 - **Training Datasets**:
   - [Nemotron-Pretraining-Specialized-v1.1](https://huggingface.co/datasets/nvidia/Nemotron-Pretraining-Specialized-v1.1) (Synthetic pretraining data)
 - **Megatron-Bridge Docs**: [Nemotron 3 Super](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/super-v3/docs/models/llm/nemotron3-super.md)

--- a/docs/nemotron/super3/README.md
+++ b/docs/nemotron/super3/README.md
@@ -62,7 +62,7 @@ $ uv run nemotron super3 eval --run YOUR-CLUSTER
 
 ## Resources
 
-- **Tech Report**: Nemotron 3 Super Technical Report (coming soon)
+- **Tech Report**: [Nemotron 3 Super Technical Report](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Super-Technical-Report.pdf)
 - **Model Weights**:
   - [NVIDIA-Nemotron-3-Super-120B-A12B-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16) (Post-trained model)
   - [NVIDIA-Nemotron-3-Super-120B-A12B-FP8](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8) (FP8 quantized)
@@ -104,7 +104,7 @@ $ uv run nemotron super3 eval --run YOUR-CLUSTER
 | **MTP Layers** | 2 (shared weight) |
 | **Precision** | BF16 mixed (NVFP4 for pretrain on B200) |
 
-> For architecture details, see the Tech Report (coming soon).
+> For architecture details, see the [Tech Report](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Super-Technical-Report.pdf).
 
 ## Stage Summaries
 

--- a/docs/nemotron/super3/pretrain.md
+++ b/docs/nemotron/super3/pretrain.md
@@ -400,7 +400,7 @@ After pretraining completes, proceed to [Stage 1: SFT](./sft.md) for instruction
 
 ## Reference
 
-- Nemotron 3 Super Tech Report (coming soon) — Pretraining methodology
+- [Nemotron 3 Super Tech Report](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Super-Technical-Report.pdf) — Pretraining methodology
 - [Megatron-Bridge Nemotron 3 Super](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/super-v3/docs/models/llm/nemotron3-super.md) — MB documentation and examples
 - [NVIDIA AI Stack](../nvidia-stack.md) — Megatron-Core, Megatron-Bridge documentation
 - [Artifact Lineage](../../nemo_runspec/artifacts.md) — W&B artifact system

--- a/docs/nemotron/super3/quantization.md
+++ b/docs/nemotron/super3/quantization.md
@@ -219,7 +219,7 @@ This stage uses the following components from the [NVIDIA AI Stack](../nvidia-st
 
 ## Reference
 
-- Nemotron 3 Super Tech Report (coming soon) — Quantization methodology
+- [Nemotron 3 Super Tech Report](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Super-Technical-Report.pdf) — Quantization methodology
 - [Megatron-Bridge Nemotron 3 Super](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/super-v3/docs/models/llm/nemotron3-super.md) — MB documentation and examples
 - [Model-Optimizer](https://github.com/NVIDIA/TensorRT-Model-Optimizer) — PTQ and AutoQuantize
 - [NVIDIA AI Stack](../nvidia-stack.md) — Megatron-Core, Megatron-Bridge, Transformer Engine

--- a/docs/nemotron/super3/sft.md
+++ b/docs/nemotron/super3/sft.md
@@ -420,7 +420,7 @@ After SFT completes, proceed to [Stage 2: RL](./rl/index.md) for reinforcement l
 
 ## Reference
 
-- Nemotron 3 Super Tech Report (coming soon) — SFT methodology
+- [Nemotron 3 Super Tech Report](https://research.nvidia.com/labs/nemotron/files/NVIDIA-Nemotron-3-Super-Technical-Report.pdf) — SFT methodology
 - [Megatron-Bridge Nemotron 3 Super](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/super-v3/docs/models/llm/nemotron3-super.md) — MB documentation and examples
 - [NVIDIA AI Stack](../nvidia-stack.md) — Megatron-Core, Megatron-Bridge documentation
 - [Artifact Lineage](../../nemo_runspec/artifacts.md) — W&B artifact system

--- a/src/nemotron/recipes/super3/stage1_sft/config/default.yaml
+++ b/src/nemotron/recipes/super3/stage1_sft/config/default.yaml
@@ -46,4 +46,4 @@ checkpoint:
 # publishes it as a separate W&B artifact with -hf suffix.
 convert_to_hf:
   enabled: true
-  hf_model_id: "nvidia/Llama-3_3-Nemotron-Super-49B-v1"
+  hf_model_id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16"

--- a/src/nemotron/recipes/super3/stage1_sft/config/test.yaml
+++ b/src/nemotron/recipes/super3/stage1_sft/config/test.yaml
@@ -38,4 +38,4 @@ checkpoint:
 # Disabled for tiny/CI runs
 convert_to_hf:
   enabled: false
-  hf_model_id: "nvidia/Llama-3_3-Nemotron-Super-49B-v1"
+  hf_model_id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16"


### PR DESCRIPTION
The SFT convert_to_hf step was pointed at the previous-generation Llama-3_3-Nemotron-Super-49B-v1 as a placeholder while the real HF repo was unpublished, which would have yielded a misconfigured export (wrong tokenizer/architecture) for the Nemotron 3 Super MoE/Mamba hybrid. Swap it to the now-published NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16 and link all four published HF model repos from the Super3 README.