### PR TITLE
feat(embed): launch finetune with torchrun for multi-GPU support

### DIFF
--- a/src/nemotron/cli/commands/embed/finetune.py
+++ b/src/nemotron/cli/commands/embed/finetune.py
@@ -115,7 +115,9 @@ def _execute_uv_local(train_path: Path, passthrough: list[str]) -> None:
         uv_cmd, "run",
         "--with", str(repo_root),
         "--project", str(stage_dir),
-        "python", str(script_abs),
+        "python", "-m", "torch.distributed.run",
+        "--nproc_per_node=gpu",
+        str(script_abs),
         "--config", str(train_path),
         *passthrough,
     ]

--- a/src/nemotron/recipes/embed/stage2_finetune/train.py
+++ b/src/nemotron/recipes/embed/stage2_finetune/train.py
@@ -8,7 +8,7 @@
 # setup = "PyTorch pre-installed. Stage dependencies resolved via UV at runtime."
 #
 # [tool.runspec.run]
-# launch = "direct"
+# launch = "torchrun"
 #
 # [tool.runspec.config]
 # dir = "./config"


### PR DESCRIPTION
Use torch.distributed.run with --nproc_per_node=gpu so training automatically uses all available GPUs (works correctly with 1 GPU too).
