### PR TITLE
docs: Replace READMEs with summary pages

### DIFF
--- a/docs/application-examples.md
+++ b/docs/application-examples.md
@@ -1,0 +1,92 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!--
+Card footer badges
+==================
+Add a badge only when the attribute applies. Omit it (and do not substitute its opposite) when it does not.
+Absence is the signal for the simpler case.
+
+{bdg-success}`Notebook`  — self-contained notebook; no environment beyond pip install.
+                           Omit for multi-file projects and anything that isn't a notebook.
+
+{bdg-secondary}`Local GPU` — requires a local GPU or hardware beyond a laptop or desktop.
+                           Omit for API/cloud-only examples. Do not add an "API" badge.
+
+{bdg-info}`Fine-tuning`  — example includes a training/fine-tuning step.
+                           Omit for inference-only examples. Do not add an "Inference" badge.
+-->
+
+(application-examples)=
+# Application Examples
+
+End-to-end applications built on Nemotron models, including agentic workflows, RAG systems, and fine-tuning pipelines. Each card links to its directory in the [Nemotron GitHub repository](https://github.com/NVIDIA-NeMo/nemotron).
+
+::::{grid} 1 2 2 2
+:gutter: 3
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron 3 Super Getting Started Guide
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/use-case-examples/Nemotron-3-Super-Getting-Started-Guide
+:link-type: url
+
+Introductory notebook covering Nemotron 3 Super's reasoning features: thinking, reasoning budget, low effort mode, streaming responses, tool-call streaming, and Perplexity Search integration using the OpenAI-compatible API.
++++
+{bdg-success}`Notebook` {bdg-muted-line}`Mar 11, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` SQL LoRA Fine-tuning and Deployment
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/use-case-examples/sql-lora-finetuning-and-deployment
+:link-type: url
+
+End-to-end LoRA fine-tuning of Nemotron 3 Nano on Text2SQL (BIRD SQL) with deployment via NVIDIA NIM or vLLM using NeMo AutoModel or Megatron Bridge.
++++
+{bdg-secondary}`Local GPU` {bdg-info}`Fine-tuning` {bdg-muted-line}`Mar 11, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Intelligent Document Processing
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/use-case-examples/Intelligent%20Document%20Processing%20with%20Nemotron%20RAG
+:link-type: url
+
+IDP pipeline that extracts and queries complex enterprise documents — financial reports, charts, and tables — using NeMo Retriever and multimodal Nemotron models.
++++
+{bdg-secondary}`Local GPU` {bdg-muted-line}`Feb 09, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Voice RAG Agent
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/use-case-examples/nemotron-voice-rag-agent-example
+:link-type: url
+
+End-to-end voice-driven RAG agent combining speech-to-text, multimodal retrieval, 1M-token reasoning, and safety guardrails using open Nemotron models.
++++
+{bdg-secondary}`Local GPU` {bdg-muted-line}`Jan 07, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Simple Nemotron 3 Nano Usage
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/use-case-examples/Simple%20Nemotron-3-Nano%20Usage%20Example
+:link-type: url
+
+Introductory notebook covering basic inference, reasoning mode toggling, and multi-agent systems using the OpenAI-compatible API via OpenRouter and LangChain.
++++
+{bdg-success}`Notebook` {bdg-muted-line}`Dec 15, 2025`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Data Science ML Agent
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/use-case-examples/Data%20Science%20ML%20Agent
+:link-type: url
+
+Natural language-driven ML agent built on Nemotron Nano 9B with GPU-accelerated data exploration and model training using RAPIDS cuDF and cuML.
++++
+{bdg-secondary}`Local GPU` {bdg-muted-line}`Nov 06, 2025`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` RAG Agent
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/use-case-examples/RAG%20Agent%20with%20Nemotron%20RAG%20Models
+:link-type: url
+
+Production-ready RAG agent using local Hugging Face embedding and reranking models with NVIDIA AI Endpoints for LLM inference, built on LangGraph.
++++
+{bdg-secondary}`Local GPU` {bdg-muted-line}`Oct 28, 2025`
+:::
+
+::::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,9 @@ html_theme_options = {
 html_extra_path = ["project.json", "versions1.json"]
 
 # Github links are now getting rate limited from the Github Actions
-linkcheck_ignore = [
-    ".*github\\.com.*",
-    ".*githubusercontent\\.com.*",
-]
+if os.environ.get("CI", False):
+    linkcheck_ignore = [
+        ".*github\\.com.*",
+        ".*githubusercontent\\.com.*",
+    ]
+

--- a/docs/deployment-guides.md
+++ b/docs/deployment-guides.md
@@ -1,0 +1,104 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+<!--
+Card footer badges
+
+Add a badge only when the attribute applies. Omit it (and do not substitute its opposite) when it does not.
+Absence is the signal for the simpler case.
+
+{bdg-success}`Beginner`  — no GPU required and no fine-tuning step. Uses an API or cloud endpoint.
+                           Add when no other attribute badges apply.
+
+{bdg-success}`Notebook`  — self-contained notebook and no environment beyond pip install.
+                           Omit for multi-file projects.
+
+{bdg-secondary}`Local GPU` — requires a local GPU or managed hardware.
+                           Omit for API/cloud-only examples.
+
+{bdg-info}`Fine-tuning`  — example includes a training or fine-tuning step.
+                           Omit for inference-only examples.
+-->
+
+(deployment-guides)=
+# Deployment Guides
+
+Deployment guides, fine-tuning recipes, and agentic usage examples for Nemotron models. Each card links to its directory in the [Nemotron GitHub repository](https://github.com/NVIDIA-NeMo/nemotron).
+
+::::{grid} 1 2 2 2
+:gutter: 3
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron 3 Super
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-3-Super
+:link-type: url
+
+Notebooks for deploying the 120B/12B-active hybrid Mamba-Transformer MoE model with vLLM, SGLang, and TensorRT-LLM.
++++
+{bdg-success}`Notebook` {bdg-secondary}`Local GPU` {bdg-muted-line}`Apr 28, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron 3 Super — LoRA Text2SQL
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-3-Super/lora-text2sql
+:link-type: url
+
+Supervised fine-tuning with LoRA for Text2SQL using the BIRD SQL benchmark. Includes recipes for both NeMo AutoModel and Megatron Bridge.
++++
+{bdg-secondary}`Local GPU` {bdg-info}`Fine-tuning` {bdg-muted-line}`Apr 28, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron 3 Super on DGX Spark
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-3-Super/SparkDeploymentGuide
+:link-type: url
+
+Deploy on a single DGX Spark with 128 GB unified memory using vLLM (nightly) and TensorRT-LLM, including NVFP4 quantization and MTP speculative decoding.
++++
+{bdg-secondary}`Local GPU` {bdg-muted-line}`Apr 10, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron 3 Ultra Base
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-3-Ultra-Base
+:link-type: url
+
+550B total / 55B active parameter base model checkpoint announced at GTC 2026. A starting point for custom fine-tuning and RL post-training pipelines — not yet instruction-tuned.
++++
+{bdg-secondary}`Local GPU` {bdg-info}`Fine-tuning` {bdg-muted-line}`Mar 23, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron 3 Super on GRPO/DAPO RL Training
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-3-Super/grpo-dapo
+:link-type: url
+
+Full-weight RL training from a base model using the GRPO/DAPO algorithm to reproduce emergent math reasoning. Requires 5× GB200 or 3× B200 nodes.
++++
+{bdg-secondary}`Local GPU` {bdg-info}`Fine-tuning` {bdg-muted-line}`Mar 11, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron 3 Super on Agentic Coding
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-3-Super/OpenScaffoldingResources
+:link-type: url
+
+Use Nemotron 3 Super with OpenCode, OpenClaw, Kilo Code CLI, and OpenHands via OpenRouter and build.nvidia.com.
++++
+{bdg-success}`Beginner` {bdg-muted-line}`Mar 11, 2026`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron Nano 2 VL
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-Nano2-VL
+:link-type: url
+
+Notebooks for the 12B multimodal model that unifies visual and textual understanding. Covers NIM inference via build.nvidia.com and local Hugging Face deployment.
++++
+{bdg-success}`Notebook` {bdg-secondary}`Local GPU` {bdg-muted-line}`Oct 28, 2025`
+:::
+
+:::{grid-item-card} {octicon}`mark-github;1.5em;sd-mr-1` Nemotron Parse v1.1
+:link: https://github.com/NVIDIA-NeMo/nemotron/tree/main/usage-cookbook/Nemotron-Parse-v1.1
+:link-type: url
+
+Notebook for the document-parsing VLM that converts PDFs and unstructured documents into structured JSON, LaTeX, and Markdown. Available via NIM at build.nvidia.com.
++++
+{bdg-success}`Beginner` {bdg-success}`Notebook` {bdg-muted-line}`Oct 28, 2025`
+:::
+
+::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
 # Nemotron Training Recipes
 
 **Open and efficient models for agentic AI.** Reproducible training pipelines with transparent data, techniques, and weights.
@@ -28,20 +32,20 @@ $ uv run nemotron nano3 rl --run YOUR-CLUSTER
 
 > **Note**: The `--run YOUR-CLUSTER` flag submits jobs to your configured Slurm cluster via [NeMo-Run](nemo_runspec/nemo-run.md). See [Execution through NeMo-Run](nemo_runspec/nemo-run.md) for setup instructions.
 
-## Usage Cookbook & Examples
+## Sample Deployments and Applications
 
 ::::{grid} 1 2 2 2
 :gutter: 3
 
-:::{grid-item-card} Usage Cookbook
-:link: usage-cookbook/README
+:::{grid-item-card} Deployment Guides
+:link: deployment-guides
 :link-type: doc
 
 Deployment guides for Nemotron models: TensorRT-LLM, vLLM, SGLang, NIM, and Hugging Face.
 :::
 
-:::{grid-item-card} Use Case Examples
-:link: use-case-examples/README
+:::{grid-item-card} Sample Applications
+:link: application-examples
 :link-type: doc
 
 End-to-end applications: RAG agents, ML agents, and multi-agent systems.
@@ -49,7 +53,7 @@ End-to-end applications: RAG agents, ML agents, and multi-agent systems.
 
 ::::
 
-## Available Training Recipes
+## Training Recipes
 
 ::::{grid} 1 2 2 2
 :gutter: 3
@@ -129,35 +133,12 @@ Each recipe family has its own stage layout, and all of them can be tracked thro
 - [Artifact Lineage](nemotron/artifacts.md) – W&B integration guide
 
 ```{toctree}
-:caption: Usage Cookbook
+:caption: Nemotron
 :hidden:
 
-usage-cookbook/README.md
-usage-cookbook/Nemotron-Nano2-VL/README.md
-usage-cookbook/Nemotron-Parse-v1.1/README.md
-usage-cookbook/Nemotron-3-Nano-Omni/Megatron-bridge/README.md
-usage-cookbook/Nemotron-3-Nano-Omni/automodel/automodel_training_cookbook.md
-usage-cookbook/Nemotron-3-Nano-Omni/doc-intelligence-with-parse/README.md
-usage-cookbook/Nemotron-3-Super/README.md
-usage-cookbook/Nemotron-3-Super/grpo-dapo/README.md
-usage-cookbook/Nemotron-3-Super/lora-text2sql/README.md
-usage-cookbook/Nemotron-3-Super/lora-text2sql/nemo-automodel/README.md
-usage-cookbook/Nemotron-3-Super/lora-text2sql/nemo-megatron-bridge/README.md
-usage-cookbook/Nemotron-3-Super/SparkDeploymentGuide/README.md
-usage-cookbook/Nemotron-3-Super/OpenScaffoldingResources/README.md
-```
-
-```{toctree}
-:caption: Use Case Examples
-:hidden:
-
-use-case-examples/README.md
-use-case-examples/Simple Nemotron-3-Nano Usage Example/README.md
-use-case-examples/Data Science ML Agent/README.md
-use-case-examples/RAG Agent with Nemotron RAG Models/README.md
-use-case-examples/Intelligent Document Processing with Nemotron RAG/README.md
-use-case-examples/nemotron-voice-rag-agent-example/README.md
-use-case-examples/sql-lora-finetuning-and-deployment/README.md
+Home <self>
+application-examples.md
+deployment-guides.md
 ```
 
 ```{toctree}

--- a/docs/usage-cookbook
+++ b/docs/usage-cookbook
@@ -1,1 +1,0 @@
-../usage-cookbook

--- a/docs/use-case-examples
+++ b/docs/use-case-examples
@@ -1,1 +1,0 @@
-../use-case-examples


### PR DESCRIPTION
- File system links have a smell.
- The directory READMEs were incomplete and sometimes referred to files that were not part of the docs.
- Add summary pages, provide badges for scannability to assist human readers.  Include rubric for reproducability of the badging.