### PR TITLE
Rerank eval default top_k as 100

### DIFF
--- a/src/nemotron/recipes/rerank/stage3_eval/config/default.yaml
+++ b/src/nemotron/recipes/rerank/stage3_eval/config/default.yaml
@@ -35,9 +35,10 @@ k_values:
   - 1
   - 5
   - 10
+  - 100
 
 # Number of first-stage candidates to re-rank
-top_k: 10
+top_k: 100
 
 # Encoding settings
 batch_size: 128

--- a/src/nemotron/recipes/rerank/stage3_eval/eval.py
+++ b/src/nemotron/recipes/rerank/stage3_eval/eval.py
@@ -95,8 +95,8 @@ class EvalConfig(RecipeSettings):
     output_dir: Path = Field(default_factory=lambda: _OUTPUT_BASE / "output/rerank/stage3_eval", description="Directory for saving evaluation results.")
 
     # Evaluation settings
-    k_values: list[int] = Field(default_factory=lambda: [1, 5, 10], description="K values for nDCG@k metrics.")
-    top_k: int = Field(default=10, gt=0, description="Number of first-stage candidates to re-rank.")
+    k_values: list[int] = Field(default_factory=lambda: [1, 5, 10, 100], description="K values for nDCG@k metrics.")
+    top_k: int = Field(default=100, gt=0, description="Number of first-stage candidates to re-rank.")
     batch_size: int = Field(default=128, gt=0, description="Batch size for reranker scoring.")
     retrieval_batch_size: int = Field(default=32, gt=0, description="Batch size for first-stage retrieval encoding. Lower than batch_size because the embedding model processes longer sequences.")
     max_length: int = Field(default=512, gt=0, description="Maximum sequence length.")


### PR DESCRIPTION
## Summary

Updates rerank stage 3 evaluation defaults so both the packaged default config and `EvalConfig` use:

- `top_k: 100`
- `k_values: [1, 5, 10, 100]`

## Impact

`nemotron rerank eval -c default` and direct `EvalConfig()` usage now evaluate reranking at the requested cutoff values without requiring overrides.

## Validation

- `python3 -m compileall src/nemotron/recipes/rerank/stage3_eval/eval.py`
- `git diff --check`
- Verified `default.yaml` contains `top_k: 100` and `k_values` includes `100`