### PR TITLE
docs(fix): Fix TOC for training recipes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -290,45 +290,6 @@ nemotron/artifacts.md
 ```
 
 ```{toctree}
-:caption: Nano3 Stages
-:hidden:
-
-nemotron/nano3/pretrain.md
-nemotron/nano3/sft.md
-nemotron/nano3/rl.md
-nemotron/nano3/evaluate.md
-nemotron/nano3/import.md
-```
-
-```{toctree}
-:caption: Omni3 Stages
-:hidden:
-
-nemotron/omni3/README.md
-nemotron/omni3/sft.md
-nemotron/omni3/rl.md
-nemotron/omni3/rl/data-prep.md
-nemotron/omni3/architecture.md
-nemotron/omni3/inference.md
-```
-
-```{toctree}
-:caption: Super3 Stages
-:hidden:
-
-nemotron/super3/README.md
-nemotron/super3/pretrain.md
-nemotron/super3/sft.md
-nemotron/super3/rl/index.md
-nemotron/super3/rl/rlvr.md
-nemotron/super3/rl/swe.md
-nemotron/super3/rl/rlhf.md
-nemotron/super3/rl/data-prep.md
-nemotron/super3/evaluate.md
-nemotron/super3/quantization.md
-```
-
-```{toctree}
 :caption: Nemotron Kit
 :hidden:
 

--- a/docs/nemotron/super3/README.md
+++ b/docs/nemotron/super3/README.md
@@ -271,10 +271,6 @@ wandb login
 pretrain.md
 sft.md
 rl/index.md
-rl/rlvr.md
-rl/swe.md
-rl/rlhf.md
-rl/data-prep.md
 evaluate.md
 quantization.md
 ```


### PR DESCRIPTION
- Fixes the "document is referenced in multiple toctrees:" messages.
- Collapses all the recipe pages under one toctree instead of one for intros and others for details.  This was the intention in #185.