### PR TITLE
chore: No SEO for nightly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,9 @@ author = "NVIDIA Corporation"
 # Defaults to "dev" for local builds
 release = os.environ.get("DOCS_VERSION", "nightly")
 
+if release == "nightly":
+    html_meta = {"robots": "noindex, nofollow"}
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 


### PR DESCRIPTION
A nightly build is a rapidly moving target.
Search results for nightly are an unforced error.