### PR TITLE
fix(sft): apply all model overrides on the HF-weights path

### DIFF
--- a/src/nemotron/data_prep/utils/splits.py
+++ b/src/nemotron/data_prep/utils/splits.py
@@ -163,7 +163,7 @@ def realize_packed_shards_into_split_dirs(
         created_count = 0
         missing_paths = []
 
-        for shard_path in shard_paths:
+        for position, shard_path in enumerate(shard_paths):
             # Shard path is a prefix like /path/to/shard_000000
             # Actual file is shard_000000.parquet
             parquet_path_str = f"{shard_path}.parquet"
@@ -175,8 +175,13 @@ def realize_packed_shards_into_split_dirs(
                 logger.warning(f"Shard file not found: {parquet_path_str}")
                 continue
 
-            # Create symlink in split dir
-            link_path = split_dir / parquet_path.name
+            # ``{position:06d}`` preserves the shuffle (it drives the loader's sort order);
+            # ``{dataset_name}`` keeps links unique across datasets, since every dataset
+            # names its shards shard_000000.parquet... (finalize.py prefix
+            # ".../<name>/<hash>/shard"). Layout: .../datasets/<name>/<plan_hash>/shard_*.parquet
+            # -> parent.parent.name is the dataset name.
+            dataset_name = parquet_path.parent.parent.name
+            link_path = split_dir / f"{position:06d}__{dataset_name}__{parquet_path.name}"
 
             if link_path.exists() or link_path.is_symlink():
                 # Remove existing link/file to update

--- a/src/nemotron/steps/_runners/megatron_bridge.py
+++ b/src/nemotron/steps/_runners/megatron_bridge.py
@@ -97,13 +97,13 @@ def _maybe_load_hf_weights(cfg: Any, container: dict[str, Any]) -> None:
         load_hf_weights: true
         trust_remote_code: false
         hf_load:
-          # Side effects to apply when HF weights are loaded. Defaults match
-          # the prior implicit behaviour but are now explicit and overridable.
+          # Side effects to apply when HF weights are loaded. Defaults are
+          # explicit and overridable.
           clear_pretrained_checkpoint: true
           inherit_save_as_load: true
-          mirror_model_attrs: ["tensor_model_parallel_size", "pipeline_model_parallel_size",
-                               "context_parallel_size", "sequence_parallel", "seq_length",
-                               "expert_model_parallel_size", "expert_tensor_parallel_size"]
+
+    Every key under ``model:`` is re-applied onto the HF-built provider (see
+    below), so no extra knob is needed to control which overrides take effect.
     """
     hf_path = container.get("hf_model_path")
     if not hf_path:
@@ -114,20 +114,13 @@ def _maybe_load_hf_weights(cfg: Any, container: dict[str, Any]) -> None:
     bridge = AutoBridge.from_hf_pretrained(hf_path, trust_remote_code=container.get("trust_remote_code", False))
     cfg.model = bridge.to_megatron_provider(load_weights=container.get("load_hf_weights", True))
 
-    hf_load = dict(container.get("hf_load") or {})
-    mirror = hf_load.get("mirror_model_attrs") or [
-        "tensor_model_parallel_size",
-        "pipeline_model_parallel_size",
-        "context_parallel_size",
-        "sequence_parallel",
-        "seq_length",
-        "expert_model_parallel_size",
-        "expert_tensor_parallel_size",
-    ]
-    for attr in mirror:
-        value = container.get("model", {}).get(attr)
+    model_overrides = dict(container.get("model") or {})
+    model_overrides.pop("_target_", None)
+    for attr, value in model_overrides.items():
         if value is not None and hasattr(cfg.model, attr):
             setattr(cfg.model, attr, value)
+
+    hf_load = dict(container.get("hf_load") or {})
 
     if container.get("load_hf_weights", True):
         if hf_load.get("clear_pretrained_checkpoint", True):


### PR DESCRIPTION

When a Megatron-Bridge step loads base weights from HuggingFace
(`hf_model_path` set), `_maybe_load_hf_weights` rebuilds `cfg.model` from the
HF config via `AutoBridge.to_megatron_provider()`, which discards the `model:`
overrides that `_apply_section_overrides` had merged. Previously only a
hardcoded set of parallelism/seq_length attrs (TP/PP/CP/EP/ETP/SP/seq_length)
was copied back, so every other `model:` override was **silently dropped** on
the HF path — notably `calculate_per_token_loss` and `recompute_*`.

This change mirrors **every** key set under `model:` onto the rebuilt provider,
so the HF-weights path honors the same overrides as the non-HF
(`pretrained_checkpoint`) path. The now-unused `hf_load.mirror_model_attrs`
knob is removed.

Added fix for https://github.com/NVIDIA-NeMo/Nemotron/issues/239 in the same.
