### PR TITLE
docs: add VT Code guide to Nemotron-3-Ultra OpenScaffoldingResources

### DIFF
--- a/usage-cookbook/Nemotron-3-Ultra/OpenScaffoldingResources/README.md
+++ b/usage-cookbook/Nemotron-3-Ultra/OpenScaffoldingResources/README.md
@@ -3,7 +3,7 @@
 Nemotron 3 Ultra is a 550B total / 55B active-parameter mixture-of-experts
 model built for long-running agentic workflows. This guide covers config-based
 setup for **OpenCode**, **OpenClaw**, **Kilo Code CLI**, **OpenHands CLI**,
-**Hermes Agent**, and **Pi**.
+**Hermes Agent**, **Pi**, and **VT Code**.
 
 The hosted model ID is:
 
@@ -318,4 +318,45 @@ Create or edit `~/.pi/agent/settings.json`:
 ```bash
 cd /path/to/project
 pi
+```
+
+## VT Code
+
+[VT Code](https://github.com/vinhnx/vtcode) is a Rust-native terminal coding
+agent with safe workspace tools and multi-provider LLM support. Configure it
+via `vtcode.toml` in your project root.
+
+**Install**
+
+```bash
+cargo install vtcode
+```
+
+**Configure**
+
+Via HuggingFace:
+
+```bash
+export HF_TOKEN="hf_..."
+```
+
+```toml
+[agent]
+provider = "huggingface"
+default_model = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4:together"
+```
+
+Via OpenRouter:
+
+```toml
+[agent]
+provider = "openrouter"
+default_model = "nvidia/nemotron-3-ultra-550b-a55b"
+```
+
+**Run**
+
+```bash
+cd /path/to/project
+vtcode
 ```

--- a/usage-cookbook/Nemotron-3-Ultra/OpenScaffoldingResources/README.md
+++ b/usage-cookbook/Nemotron-3-Ultra/OpenScaffoldingResources/README.md
@@ -346,13 +346,9 @@ provider = "huggingface"
 default_model = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4:together"
 ```
 
-Via OpenRouter:
-
-```toml
 [agent]
 provider = "openrouter"
 default_model = "nvidia/nemotron-3-ultra-550b-a55b"
-```
 
 **Run**
 


### PR DESCRIPTION
Adds a [VT Code](https://github.com/vinhnx/vtcode) section to the Nemotron-3-Ultra agentic coding tools guide with configuration examples for both HuggingFace and OpenRouter providers.

VT Code is a Rust-native terminal coding agent with a native HuggingFace provider that supports Nemotron-3-Ultra as `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4:together`.