### PR TITLE
docs(oci): keep Nano-8B private-OKE cookbook working on current OKE (follow-up to #117)

### DIFF
--- a/usage-cookbook/Llama-3.1-Nemotron-Nano-8B-v1/README.md
+++ b/usage-cookbook/Llama-3.1-Nemotron-Nano-8B-v1/README.md
@@ -67,7 +67,15 @@ export OCI_COMPARTMENT_ID="<your-compartment-ocid>"
 export OCI_REGION="us-phoenix-1"
 export OCI_PROFILE="DEFAULT"          # adjust to your OCI CLI profile
 export CLUSTER_NAME="nemotron-phx"
-export KUBERNETES_VERSION="v1.31.10"
+
+# OKE retires older Kubernetes minors over time, so the example below may no
+# longer be offered in your region. List the versions OKE currently supports
+# and pick one of them:
+#   oci ce cluster-options get --cluster-option-id all \
+#       --compartment-id "${OCI_COMPARTMENT_ID}" \
+#       --profile "${OCI_PROFILE}" --region "${OCI_REGION}" \
+#       --query 'data."kubernetes-versions"'
+export KUBERNETES_VERSION="v1.33.1"   # must be a version OKE currently lists
 ```
 
 ## Step 2: Create VCN and networking
@@ -253,7 +261,10 @@ BASTION_ID=$(oci bastion bastion create \
 
 ## Step 5: Create node pools
 
-Find the GPU-compatible node image and create both pools:
+Find the GPU-compatible node image and create both pools. The `OKE-<ver>-`
+match is anchored with a trailing dash on purpose: a bare `OKE-1.33.1` also
+substring-matches `OKE-1.33.10` images, which would pick a node image newer
+than the control plane and be rejected for version skew.
 
 ```bash
 GPU_IMAGE_ID=$(oci ce node-pool-options get \
@@ -261,14 +272,14 @@ GPU_IMAGE_ID=$(oci ce node-pool-options get \
     --compartment-id "${OCI_COMPARTMENT_ID}" \
     --profile "${OCI_PROFILE}" --region "${OCI_REGION}" \
     --query "data.sources[?contains(\"source-name\", 'GPU') && \
-             contains(\"source-name\", 'OKE-${KUBERNETES_VERSION#v}')].\"image-id\" | [0]" \
+             contains(\"source-name\", 'OKE-${KUBERNETES_VERSION#v}-')].\"image-id\" | [0]" \
     --raw-output)
 
 CPU_IMAGE_ID=$(oci ce node-pool-options get \
     --node-pool-option-id all \
     --compartment-id "${OCI_COMPARTMENT_ID}" \
     --profile "${OCI_PROFILE}" --region "${OCI_REGION}" \
-    --query "data.sources[?contains(\"source-name\", 'OKE-${KUBERNETES_VERSION#v}') && \
+    --query "data.sources[?contains(\"source-name\", 'OKE-${KUBERNETES_VERSION#v}-') && \
              !contains(\"source-name\", 'GPU') && \
              contains(\"source-name\", 'aarch64')==\`false\`].\"image-id\" | [0]" \
     --raw-output)
@@ -280,7 +291,7 @@ echo "CPU image: ${CPU_IMAGE_ID}"
 # oci ce node-pool-options get --node-pool-option-id all \
 #     --compartment-id "${OCI_COMPARTMENT_ID}" \
 #     --profile "${OCI_PROFILE}" --region "${OCI_REGION}" \
-#     --query "data.sources[?contains(\"source-name\", 'OKE-${KUBERNETES_VERSION#v}')].{name:\"source-name\",id:\"image-id\"}" \
+#     --query "data.sources[?contains(\"source-name\", 'OKE-${KUBERNETES_VERSION#v}-')].{name:\"source-name\",id:\"image-id\"}" \
 #     --output table
 
 # Pick an availability domain with A10 capacity.
@@ -512,6 +523,11 @@ done
 
 Expected: CPU node ~`93476416Ki` (~89 GiB), GPU node ~`198056192Ki` (~189 GiB).
 If either still shows ~`37206272Ki`, rerun the soft-reset for that node.
+
+Note: a node can report `Ready` slightly before kubelet republishes the new
+`ephemeral-storage` capacity, so the value may briefly still read
+~`37206272Ki` right after uncordon. Re-check after ~60s before concluding a
+rerun is needed.
 
 ## Step 8: Create StorageClasses
 


### PR DESCRIPTION
## Summary

Follow-up to #117 — the private OCI OKE cookbook for `nvidia/Llama-3.1-Nemotron-Nano-8B-v1`, which merged on 2026-06-24 (`13ea03d`).

#117 was open for a fair while before it landed, and the managed OKE service moved on during that window. Re-running the **merged** cookbook end-to-end today surfaced a few spots that no longer work exactly as written. This PR fixes them. All three were found and verified by actually deploying the cookbook on a fresh private A10 OKE cluster in `us-phoenix-1`.

The original cookbook is solid — these are drift fixes plus one race-condition note, so it keeps working for the next person who runs it.

## Fixes

1. **Step 1 — drop the EOL Kubernetes pin.** The cookbook hard-coded `KUBERNETES_VERSION="v1.31.10"`, which OKE no longer offers (the oldest available is now `v1.33.x`), so `oci ce cluster create` fails up front. Bumped the example to `v1.33.1` and added an `oci ce cluster-options get` snippet so readers pick a version OKE currently lists.

2. **Step 5 — anchor the node-image match.** The image lookup used `contains("source-name", 'OKE-${KUBERNETES_VERSION#v}')`, which also substring-matches `OKE-1.33.10` images when the version is `1.33.1` — that can select a node image **newer than the control plane** and gets rejected for version skew. Added a trailing dash (`'OKE-<ver>-'`). This was latent with `v1.31.10` (no `.100` sibling) and only bites once you move to a current version — i.e. the moment you apply fix #1.

3. **Step 7b — note the capacity/Ready race.** A node can report `Ready` slightly before kubelet republishes the expanded `ephemeral-storage`, so the verification step can briefly still read the stale `~37206272Ki` and push the reader into an unnecessary soft-reset rerun. Added a note to re-check after ~60s first.

## Re-validation

Deployed the fixed cookbook end-to-end on a fresh private OKE cluster — single `VM.GPU.A10.1`, `us-phoenix-1`, k8s `v1.33.1`, upstream `vllm/vllm-openai:v0.19.0`:

- `/health` → `{"status":"healthy"}`
- `/v1/models` → `nvidia/Llama-3.1-Nemotron-Nano-8B-v1`
- chat completion → returns content
- tool calling → `finish_reason: "tool_calls"`

Doc-only change to `usage-cookbook/Llama-3.1-Nemotron-Nano-8B-v1/README.md`. DCO signed off.