### PR TITLE
docs: fix broken nemo_runspec package-readme links

### DIFF
--- a/docs/architecture/cli-architecture.md
+++ b/docs/architecture/cli-architecture.md
@@ -59,7 +59,7 @@ Recipe scripts are self-describing. Each script declares its identity, container
 # ///
 ```
 
-The CLI reads this via `nemo_runspec.parse()`, returning a frozen `Runspec` dataclass. See [nemo_runspec package](../nemo_runspec/package-readme) for the full schema.
+The CLI reads this via `nemo_runspec.parse()`, returning a frozen `Runspec` dataclass. See [nemo_runspec package](../nemo_runspec/package-readme.md) for the full schema.
 
 ### RecipeConfig
 

--- a/docs/nemotron/cli.md
+++ b/docs/nemotron/cli.md
@@ -1,6 +1,6 @@
 # CLI Framework
 
-The CLI framework is built on [Typer](https://typer.tiangolo.com/) and [`nemo_runspec`](../nemo_runspec/package-readme). Each command file contains its own execution logic, so you can see exactly how jobs are submitted.
+The CLI framework is built on [Typer](https://typer.tiangolo.com/) and [`nemo_runspec`](../nemo_runspec/package-readme.md). Each command file contains its own execution logic, so you can see exactly how jobs are submitted.
 
 <div class="termy">
 
@@ -60,7 +60,7 @@ The CLI framework supports:
 - **[Remote execution](../nemo_runspec/nemo-run.md)** via NeMo-Run with `--run` / `--batch`
 - **Visible execution** with all submission logic in each command file
 
-For artifacts, see [Nemotron Kit](./kit.md). For execution profiles, see [Execution through NeMo-Run](../nemo_runspec/nemo-run.md). For the full `nemo_runspec` toolkit, see the [nemo_runspec package readme](../nemo_runspec/package-readme).
+For artifacts, see [Nemotron Kit](./kit.md). For execution profiles, see [Execution through NeMo-Run](../nemo_runspec/nemo-run.md). For the full `nemo_runspec` toolkit, see the [nemo_runspec package readme](../nemo_runspec/package-readme.md).
 
 ## Architecture
 
@@ -480,7 +480,7 @@ uv run nemotron myrecipe train -c tiny --run MY-CLUSTER
 ## Further Reading
 
 - [Nemotron Kit](./kit.md) – artifacts and lineage tracking
-- [`nemo_runspec` Package](../nemo_runspec/package-readme) – toolkit documentation
+- [`nemo_runspec` Package](../nemo_runspec/package-readme.md) – toolkit documentation
 - [Execution through NeMo-Run](../nemo_runspec/nemo-run.md) – execution profiles and env.toml
 - [Data Preparation](./data-prep.md) – data preparation module
 - [Artifact Lineage](./artifacts.md) – W&B artifact system and lineage tracking

--- a/docs/nemotron/kit.md
+++ b/docs/nemotron/kit.md
@@ -2,7 +2,7 @@
 
 The `nemotron.kit` module provides artifact type definitions, lineage trackers, and W&B integration for Nemotron training recipes.
 
-> **Focused by Design**: Kit owns the artifact *types* (data classes like `PretrainBlendsArtifact`, `ModelArtifact`) and *tracking behavior* (W&B/file-based lineage). The underlying artifact *registry* and *resolution* (`art://` URIs, fsspec/wandb storage backends) live in [`nemo_runspec`](../nemo_runspec/package-readme). CLI, configuration, and execution also live in `nemo_runspec`. All heavy-lifting training is done by the [NVIDIA AI Stack](./nvidia-stack.md): [Megatron-Core](https://github.com/NVIDIA/Megatron-LM) for distributed training primitives, [Megatron-Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) for model training, and [NeMo-RL](https://github.com/NVIDIA/NeMo-RL) for reinforcement learning.
+> **Focused by Design**: Kit owns the artifact *types* (data classes like `PretrainBlendsArtifact`, `ModelArtifact`) and *tracking behavior* (W&B/file-based lineage). The underlying artifact *registry* and *resolution* (`art://` URIs, fsspec/wandb storage backends) live in [`nemo_runspec`](../nemo_runspec/package-readme.md). CLI, configuration, and execution also live in `nemo_runspec`. All heavy-lifting training is done by the [NVIDIA AI Stack](./nvidia-stack.md): [Megatron-Core](https://github.com/NVIDIA/Megatron-LM) for distributed training primitives, [Megatron-Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) for model training, and [NeMo-RL](https://github.com/NVIDIA/NeMo-RL) for reinforcement learning.
 
 ## Overview
 
@@ -14,7 +14,7 @@ Kit handles three core responsibilities:
 | **[Lineage Tracking](./artifacts.md)** | Trackers (`WandbTracker`, `FileTracker`) | `${art:...}` OmegaConf resolvers, distributed coordination |
 | **[W&B Integration](./wandb.md)** | Init, credential handling, monkey patches, tag management | Env var injection (`build_env_vars`), `[wandb]` config loading |
 
-For CLI infrastructure, config loading, execution, and packaging, see [`nemo_runspec`](../nemo_runspec/package-readme).
+For CLI infrastructure, config loading, execution, and packaging, see [`nemo_runspec`](../nemo_runspec/package-readme.md).
 
 ## Architecture
 
@@ -185,7 +185,7 @@ src/nemotron/kit/
 
 ## Further Reading
 
-- [`nemo_runspec` Package](../nemo_runspec/package-readme) – CLI toolkit, config loading, execution, packaging
+- [`nemo_runspec` Package](../nemo_runspec/package-readme.md) – CLI toolkit, config loading, execution, packaging
 - [NVIDIA AI Stack](./nvidia-stack.md) – Megatron-Core, Megatron-Bridge, NeMo-RL
 - [OmegaConf Configuration](../nemo_runspec/omegaconf.md) – artifact interpolations and unified W&B logging
 - [Artifact Lineage](./artifacts.md) – artifact versioning and W&B lineage


### PR DESCRIPTION
Small docs fix. Seven relative links to the nemo_runspec package readme are missing the .md extension, so they point at ../nemo_runspec/package-readme which does not resolve. The file lives at docs/nemo_runspec/package-readme.md, and every other relative link in these files already uses .md, so this just adds it.