### PR TITLE
Fix PyPI project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,9 @@ all = [
 #   pip install megatron-bridge>=0.1.0
 
 [project.urls]
-Homepage = "https://github.com/nemotron/nemotron"
-Documentation = "https://github.com/nemotron/nemotron#readme"
-Repository = "https://github.com/nemotron/nemotron"
+Homepage = "https://github.com/NVIDIA-NeMo/Nemotron"
+Documentation = "https://github.com/NVIDIA-NeMo/Nemotron#readme"
+Repository = "https://github.com/NVIDIA-NeMo/Nemotron"
 
 [project.scripts]
 nemotron = "nemotron.__main__:main"

--- a/tests/nemo_runspec/test_pyproject.py
+++ b/tests/nemo_runspec/test_pyproject.py
@@ -38,3 +38,15 @@ def test_write_temp_pyproject_preserves_extras_sources_and_indexes() -> None:
         assert "transformer-engine" in uv["exclude-dependencies"]
     finally:
         shutil.rmtree(temp_dir)
+
+
+def test_root_project_urls_point_to_canonical_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+
+    with open(repo_root / "pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+
+    project_urls = data["project"]["urls"]
+    assert project_urls["Homepage"] == "https://github.com/NVIDIA-NeMo/Nemotron"
+    assert project_urls["Documentation"] == "https://github.com/NVIDIA-NeMo/Nemotron#readme"
+    assert project_urls["Repository"] == "https://github.com/NVIDIA-NeMo/Nemotron"


### PR DESCRIPTION
## Summary
- update the root `project.urls` metadata in `pyproject.toml` to the canonical `NVIDIA-NeMo/Nemotron` repository
- add a small regression test that pins those PyPI-facing URLs to the canonical repo

## Why
The package metadata still pointed at `https://github.com/nemotron/nemotron`, while the README and docs consistently reference `https://github.com/NVIDIA-NeMo/Nemotron`. PyPI and tooling consumers should land on the live canonical repository.

## Validation
- `python3 -m py_compile tests/nemo_runspec/test_pyproject.py`
- `uv run --no-project --with pytest --with fsspec env PYTHONPATH=src pytest tests/nemo_runspec/test_pyproject.py`
