### PR TITLE
Apply per-shard row partition in binidx pretrain processing

### DIFF
--- a/src/nemotron/data_prep/core/shard_processor.py
+++ b/src/nemotron/data_prep/core/shard_processor.py
@@ -297,6 +297,8 @@ def _process_file_core(
             tokenize=tokenize,
             rows_processed=rows_processed,
             max_rows=max_rows,
+            row_modulus=file_info.row_modulus,
+            row_remainder=file_info.row_remainder,
         )
     else:
         rows_processed, tokenize_time = _process_jsonl_file_core(
@@ -310,6 +312,8 @@ def _process_file_core(
             tokenize=tokenize,
             rows_processed=rows_processed,
             max_rows=max_rows,
+            row_modulus=file_info.row_modulus,
+            row_remainder=file_info.row_remainder,
         )
 
     return rows_processed, tokenize_time
@@ -350,6 +354,8 @@ def _process_parquet_file_core(
     tokenize: Callable[[list[str]], list[list[int]]],
     rows_processed: int,
     max_rows: int | None,
+    row_modulus: int | None = None,
+    row_remainder: int | None = None,
 ) -> tuple[int, float]:
     """Process parquet file with optimized Arrow-level filtering.
 
@@ -370,10 +376,14 @@ def _process_parquet_file_core(
         if is_remote:
             with input_fs.open(local_path, "rb") as f:
                 parquet_file = pq.ParquetFile(f)
-                yield from _iter_parquet_batches_internal(parquet_file, text_field, min_doc_chars)
+                yield from _iter_parquet_batches_internal(
+                    parquet_file, text_field, min_doc_chars, row_modulus, row_remainder
+                )
         else:
             parquet_file = pq.ParquetFile(local_path)
-            yield from _iter_parquet_batches_internal(parquet_file, text_field, min_doc_chars)
+            yield from _iter_parquet_batches_internal(
+                parquet_file, text_field, min_doc_chars, row_modulus, row_remainder
+            )
 
     for texts, num_filtered_by_length in iter_parquet_batches():
         if hit_max_rows:
@@ -421,15 +431,30 @@ def _iter_parquet_batches_internal(
     parquet_file: pq.ParquetFile,
     text_field: str,
     min_doc_chars: int | None,
+    row_modulus: int | None = None,
+    row_remainder: int | None = None,
 ) -> Iterator[tuple[list[str | None], int]]:
     """Iterate batches from parquet file efficiently."""
+    import pyarrow as pa
     import pyarrow.compute as pc
 
+    row_offset = 0
     for batch in parquet_file.iter_batches(
         columns=[text_field],
         batch_size=10000,
     ):
         column = batch.column(text_field)
+
+        # Keep only this shard's rows (row_index % row_modulus == row_remainder).
+        # Applied on the raw row index, before any length filtering, so shards stay
+        # disjoint and together cover every row exactly once.
+        if row_modulus is not None and row_remainder is not None:
+            keep = pa.array(
+                [(row_offset + i) % row_modulus == row_remainder for i in range(len(column))]
+            )
+            column = column.filter(keep)
+        row_offset += len(batch)
+
         original_len = len(column)
         num_filtered = 0
 
@@ -456,6 +481,8 @@ def _process_jsonl_file_core(
     tokenize: Callable[[list[str]], list[list[int]]],
     rows_processed: int,
     max_rows: int | None,
+    row_modulus: int | None = None,
+    row_remainder: int | None = None,
 ) -> tuple[int, float]:
     """Process JSONL file.
 
@@ -480,7 +507,16 @@ def _process_jsonl_file_core(
                     if line.strip():
                         yield json.loads(line)
 
-    for record in iter_records():
+    for row_index, record in enumerate(iter_records()):
+        # Keep only this shard's rows (row_index % row_modulus == row_remainder),
+        # matching the per-shard partition recorded in the plan.
+        if (
+            row_modulus is not None
+            and row_remainder is not None
+            and row_index % row_modulus != row_remainder
+        ):
+            continue
+
         # Check max_rows limit
         if max_rows and rows_processed >= max_rows:
             break

--- a/tests/data_prep/test_shard_processor_partition.py
+++ b/tests/data_prep/test_shard_processor_partition.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that binidx pretrain processing applies the per-shard row partition.
+
+Regression for the bug where a file split across N shards was re-read in full by
+every shard, duplicating each document N times.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from nemotron.data_prep.core.shard_processor import _iter_parquet_batches_internal
+
+
+def _collect(path: str, modulus: int | None, remainder: int | None) -> list[str]:
+    parquet_file = pq.ParquetFile(path)
+    texts: list[str] = []
+    for batch_texts, _ in _iter_parquet_batches_internal(parquet_file, "text", None, modulus, remainder):
+        texts.extend(batch_texts)
+    return texts
+
+
+def test_row_partition_is_disjoint_and_complete(tmp_path) -> None:
+    # More rows than the internal batch size (10000) to exercise the cross-batch offset.
+    n, modulus = 25000, 8
+    path = str(tmp_path / "data.parquet")
+    pq.write_table(pa.table({"text": [f"doc-{i}" for i in range(n)]}), path)
+
+    seen: list[str] = []
+    for remainder in range(modulus):
+        part = _collect(path, modulus, remainder)
+        assert part == [f"doc-{i}" for i in range(n) if i % modulus == remainder]
+        seen.extend(part)
+
+    # Union over all shards must equal every row exactly once (no duplication, no loss).
+    assert sorted(seen) == sorted(f"doc-{i}" for i in range(n))
+    assert len(seen) == n
+
+
+def test_no_partition_processes_all_rows(tmp_path) -> None:
+    n = 100
+    path = str(tmp_path / "data.parquet")
+    pq.write_table(pa.table({"text": [f"doc-{i}" for i in range(n)]}), path)
+    assert _collect(path, None, None) == [f"doc-{i}" for i in range(n)]


### PR DESCRIPTION
When a single input file is split across N shards, the binidx pretrain core re-read and re-tokenized the whole file in every shard, because the plan's row_modulus / row_remainder were never applied. Each document got written N times (one report saw 5.5 GB turn into ~497 GB, 32x).

This applies the per-shard partition (row_index % row_modulus == row_remainder) on the raw row index, before length filtering, in both the parquet and jsonl readers, matching what jsonl_shard_core already does. Shards stay disjoint and together cover every row exactly once.

Adds a regression test that the parquet partition is disjoint and complete across batches.