### PR TITLE
Fix local data prep path doubling in filesystem discovery

### DIFF
--- a/src/nemotron/data_prep/utils/discovery.py
+++ b/src/nemotron/data_prep/utils/discovery.py
@@ -325,9 +325,12 @@ def discover_filesystem_files(
         file_paths = sorted(fs.glob(path))
     elif fs.isdir(path):
         all_files = fs.listdir(path, detail=False)
+        # fsspec listdir/ls already returns full paths (strings when detail=False,
+        # dicts with "name" when detail=True). Do not prepend `path` again, doing so
+        # doubled the path on local filesystems and raised FileNotFoundError.
         file_paths = sorted(
             [
-                f"{path.rstrip('/')}/{f}" if isinstance(f, str) else f["name"]
+                f if isinstance(f, str) else f["name"]
                 for f in all_files
                 if (isinstance(f, str) and f.endswith((".parquet", ".jsonl", ".json")))
                 or (

--- a/tests/data_prep/test_discovery.py
+++ b/tests/data_prep/test_discovery.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for filesystem input discovery."""
+
+from __future__ import annotations
+
+import os
+
+import fsspec
+
+from nemotron.data_prep.config import DatasetConfig
+from nemotron.data_prep.utils.discovery import discover_filesystem_files
+
+
+def test_discover_local_directory_does_not_double_paths(tmp_path) -> None:
+    # A local dataset directory with a couple of parquet files.
+    for name in ("a.parquet", "b.parquet"):
+        (tmp_path / name).write_bytes(b"data")
+
+    fs = fsspec.filesystem("file")
+    cfg = DatasetConfig(name="ds", path=str(tmp_path), text_field="text")
+
+    files = discover_filesystem_files(cfg, fs)
+
+    found = sorted(f.path for f in files)
+    expected = sorted(str(tmp_path / name) for name in ("a.parquet", "b.parquet"))
+    assert found == expected
+    # Regression for path doubling: every discovered path must actually exist.
+    for f in files:
+        assert os.path.exists(f.path)


### PR DESCRIPTION
discover_filesystem_files prepended the dataset path to each entry from fs.listdir(path, detail=False), but fsspec already returns full paths there. On local filesystems this doubled the path (e.g. /data/dir//data/dir/file.parquet) and raised FileNotFoundError during planning. Use the returned paths as is.

Adds a regression test using a local fsspec filesystem and a temp directory.