### PR TITLE
Fix packer dropping rows on null or whitespace-only reasoning_content (Fixes #240)

### DIFF
--- a/src/nemotron/data_prep/core/chat_template.py
+++ b/src/nemotron/data_prep/core/chat_template.py
@@ -59,6 +59,30 @@ def replace_json_args(messages: list[dict]) -> list[dict]:
     return messages
 
 
+def reasoning_renders_empty(message: dict) -> bool:
+    """Whether a turn's reasoning_content renders as an empty <think></think>.
+
+    Mirrors the chat template's own rule, which keeps the reasoning only when it
+    "is defined and is string and reasoning_content | trim | length > 0". So a
+    missing key, a non-string value like None, an empty string, and a
+    whitespace-only string such as "\\n\\n" all collapse to <think></think> as
+    far as the template is concerned, and this returns True for every one of them.
+
+    The incremental-rendering consistency check used to test only the exact
+    "missing key" and "" cases, so None and whitespace-only reasoning made the
+    incremental render diverge from the full render and the row was dropped as an
+    error. Using this helper keeps the check in lock-step with the template.
+
+    Args:
+        message: An OpenAI-format message dict.
+
+    Returns:
+        True if the template would render this turn's reasoning as empty.
+    """
+    reasoning = message.get("reasoning_content")
+    return not (isinstance(reasoning, str) and reasoning.strip())
+
+
 def find_last_user_message_end(
     messages: list[dict],
     tokenizer: PreTrainedTokenizerBase,
@@ -86,10 +110,7 @@ def find_last_user_message_end(
     last_user_idx = max(i for i, msg in enumerate(messages) if msg["role"] == "user")
 
     # Render up to the last user message (inclusive)
-    if enable_thinking and (
-        "reasoning_content" not in messages[last_user_idx + 1]
-        or messages[last_user_idx + 1]["reasoning_content"] == ""
-    ):
+    if enable_thinking and reasoning_renders_empty(messages[last_user_idx + 1]):
         # Manual hack for empty reasoning content mismatch
         template_up_to_last_user = tokenizer.apply_chat_template(
             messages[: last_user_idx + 1],
@@ -182,10 +203,7 @@ def split_template_into_messages(
             enable_thinking
             and messages[i]["role"] != "assistant"
             and i + 1 < len(messages)
-            and (
-                "reasoning_content" not in messages[i + 1]
-                or messages[i + 1]["reasoning_content"] == ""
-            )
+            and reasoning_renders_empty(messages[i + 1])
         ):
             # Manual hack for empty reasoning content mismatch
             template_up_to_here = tokenizer.apply_chat_template(
@@ -373,6 +391,7 @@ def split_system_user_chunks(chunks: list[dict]) -> list[dict]:
 
 __all__ = [
     "replace_json_args",
+    "reasoning_renders_empty",
     "find_last_user_message_end",
     "split_template_into_messages",
     "create_masked_messages",

--- a/tests/data_prep/test_chat_template_reasoning.py
+++ b/tests/data_prep/test_chat_template_reasoning.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for reasoning_content handling in chat template splitting.
+
+Regression coverage for the packer dropping valid rows when an assistant turn
+carried reasoning_content that the template renders as an empty <think></think>
+but the consistency check treated as present (None and whitespace-only strings).
+"""
+
+import pytest
+
+from nemotron.data_prep.core.chat_template import reasoning_renders_empty
+
+
+def template_renders_empty(message: dict) -> bool:
+    """Faithful model of the nano3.jinja reasoning rule, for cross-checking.
+
+    The template keeps the reasoning only when reasoning_content is defined, is
+    a string, and is non-empty after trimming. Everything else collapses to an
+    empty <think></think>. reasoning_renders_empty must agree with this exactly.
+    """
+    val = message.get("reasoning_content")
+    keeps_reasoning = (
+        "reasoning_content" in message
+        and isinstance(val, str)
+        and len(val.strip()) > 0
+    )
+    return not keeps_reasoning
+
+
+class TestReasoningRendersEmpty:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {},  # missing key
+            {"reasoning_content": None},  # null (the reported bug)
+            {"reasoning_content": ""},  # empty string (already handled before)
+            {"reasoning_content": "\n\n"},  # whitespace-only (the reported bug)
+            {"reasoning_content": "   "},  # spaces only
+            {"reasoning_content": "\t \n"},  # mixed whitespace
+            {"reasoning_content": 123},  # non-string, template treats as empty
+            {"reasoning_content": ["x"]},  # non-string, template treats as empty
+        ],
+    )
+    def test_empty_representations(self, message: dict) -> None:
+        assert reasoning_renders_empty(message) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {"reasoning_content": "thinking through the steps"},
+            {"reasoning_content": "  padded but real  "},
+            {"reasoning_content": "a"},
+        ],
+    )
+    def test_present_representations(self, message: dict) -> None:
+        assert reasoning_renders_empty(message) is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {},
+            {"reasoning_content": None},
+            {"reasoning_content": ""},
+            {"reasoning_content": "\n\n"},
+            {"reasoning_content": "   "},
+            {"reasoning_content": "\t \n"},
+            {"reasoning_content": 123},
+            {"reasoning_content": ["x"]},
+            {"reasoning_content": "thinking through the steps"},
+            {"reasoning_content": "  padded but real  "},
+        ],
+    )
+    def test_agrees_with_template_rule(self, message: dict) -> None:
+        # The whole point of the helper is to stay in lock-step with the
+        # template, so it must match the template's own trim rule on every
+        # representation a dataset can emit.
+        assert reasoning_renders_empty(message) == template_renders_empty(message)


### PR DESCRIPTION
## What

Fixes #240.

The SFT packer silently drops multi-turn rows when an assistant turn carries `reasoning_content` that is `null` or whitespace-only.

`nano3.jinja` keeps a turn's reasoning only when it `is defined and is string and reasoning_content | trim | length > 0`. So a missing key, `null`, `""`, and a whitespace-only string like `"\n\n"` all collapse to `<think></think>` as far as the template is concerned.

The incremental-rendering consistency check in `chat_template.py` only special-cased the exact "missing key" and `""` cases:

```python
"reasoning_content" not in messages[...] or messages[...]["reasoning_content"] == ""
```

So `reasoning_content: null` (Python `None`) and whitespace-only strings were treated as present. The "manual hack" branch that appends `<|im_start|>assistant\n<think></think>` was skipped, the incremental render diverged from the full render, the consistency assertion failed, and the row was counted as `num_errors` and dropped. A single such turn is enough, and `null` for a no-think turn is a very common representation, so this can quietly remove a large fraction of tool-calling data.

## The fix

Add a small `reasoning_renders_empty` helper that mirrors the template's trim rule exactly (defined, is `str`, non-empty after `strip()`), and use it at both check sites in `find_last_user_message_end` and `split_template_into_messages`. This keeps the consistency check in lock-step with the template, so the "manual hack" branch fires for every representation the template renders as empty, including `null` and whitespace-only.

I scoped the change to the two consistency-check sites named in the issue and left the `has_thinking` strategy selector alone, since changing the split strategy is a broader behavioral change that was not part of the report.

## Tests

Added `tests/data_prep/test_chat_template_reasoning.py` covering the helper against missing key, `null`, `""`, whitespace-only (`"\n\n"`, `"   "`, `"\t \n"`), non-string values, and real reasoning, plus a case that asserts the helper agrees with a faithful model of the template's trim rule on every representation.

## Verification

The package imports `cosmos_xenna` at the `data_prep` package level, so I could not run the full test suite on a plain laptop. I verified the fix logic standalone instead: modeling the Jinja rule directly and confirming `reasoning_renders_empty` matches it on every representation a dataset can emit, and confirming the old check disagreed exactly on the `null`, whitespace-only, and non-string cases. CI runs the added test.
