### PR TITLE
Fix test imports broken by the kit to nemo_runspec refactor

### DIFF
--- a/tests/data_prep/test_binidx_stage_resume.py
+++ b/tests/data_prep/test_binidx_stage_resume.py
@@ -32,7 +32,7 @@ from typing import Any
 
 import pytest
 
-from nemotron.data_prep.filesystem import read_json
+from nemotron.data_prep.utils.filesystem import read_json
 
 
 class MockFilesystem:

--- a/tests/data_prep/test_stage_keys.py
+++ b/tests/data_prep/test_stage_keys.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from nemotron.data_prep.stage_keys import (
+from nemotron.data_prep.observability.stage_keys import (
     STAGE_DISPLAY_NAMES,
     canonical_stage_id,
     get_stage_display_name,

--- a/tests/kit/cli/test_utils.py
+++ b/tests/kit/cli/test_utils.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for nemotron.kit.cli.utils module."""
+"""Tests for nemo_runspec.utils module."""
 
 import pytest
 
-from nemotron.kit.cli.utils import (
+from nemo_runspec.utils import (
     CONFIG_FILE_KEYS,
     extract_run_args,
     filter_config_file_args,

--- a/tests/kit/test_resolvers_pre_init.py
+++ b/tests/kit/test_resolvers_pre_init.py
@@ -17,7 +17,7 @@ import types
 
 from omegaconf import OmegaConf
 
-from nemotron.kit import resolvers
+from nemo_runspec.config import resolvers
 
 
 class TestGetJobId:

--- a/tests/recipes/nano3/stage0_pretrain/test_data_prep_train_integration.py
+++ b/tests/recipes/nano3/stage0_pretrain/test_data_prep_train_integration.py
@@ -33,8 +33,8 @@ from pathlib import Path
 import pytest
 from omegaconf import OmegaConf
 
-from nemotron.data_prep.filesystem import get_filesystem
-from nemotron.data_prep.pipeline import _distribute_shards_to_splits
+from nemotron.data_prep.utils.filesystem import get_filesystem
+from nemotron.data_prep.utils.splits import distribute_shards_to_splits
 from nemotron.kit import PretrainBlendsArtifact
 
 
@@ -42,10 +42,10 @@ class TestNano3DataPrepTrainIntegration:
     """Test integration between data_prep.py output and train.py consumption."""
 
     def test_distribute_shards_produces_valid_per_split_format(self):
-        """Test _distribute_shards_to_splits produces correct format."""
+        """Test distribute_shards_to_splits produces correct format."""
         data_paths = ["1.0", "/path/to/shard", "0.5", "/path/to/other"]
 
-        result = _distribute_shards_to_splits(
+        result = distribute_shards_to_splits(
             data_paths=data_paths,
             num_shards=4,
             valid_shards=1,
@@ -69,7 +69,7 @@ class TestNano3DataPrepTrainIntegration:
         """Test that valid_shards and test_shards control split sizes."""
         data_paths = ["1.0", "/path/to/shard"]
 
-        result = _distribute_shards_to_splits(
+        result = distribute_shards_to_splits(
             data_paths=data_paths,
             num_shards=10,
             valid_shards=2,
@@ -174,7 +174,7 @@ class TestNano3DataPrepTrainIntegration:
         """Test that shard paths follow the expected naming convention."""
         data_paths = ["1.0", "/output/shard"]
 
-        result = _distribute_shards_to_splits(
+        result = distribute_shards_to_splits(
             data_paths=data_paths,
             num_shards=10,
             valid_shards=1,
@@ -194,7 +194,7 @@ class TestNano3DataPrepTrainIntegration:
         """Test that shard distribution is deterministic with same seed."""
         data_paths = ["1.0", "/path/to/shard"]
 
-        result1 = _distribute_shards_to_splits(
+        result1 = distribute_shards_to_splits(
             data_paths=data_paths,
             num_shards=10,
             valid_shards=2,
@@ -202,7 +202,7 @@ class TestNano3DataPrepTrainIntegration:
             seed=42,
         )
 
-        result2 = _distribute_shards_to_splits(
+        result2 = distribute_shards_to_splits(
             data_paths=data_paths,
             num_shards=10,
             valid_shards=2,
@@ -216,7 +216,7 @@ class TestNano3DataPrepTrainIntegration:
         """Test that different seeds produce different distributions."""
         data_paths = ["1.0", "/path/to/shard"]
 
-        result1 = _distribute_shards_to_splits(
+        result1 = distribute_shards_to_splits(
             data_paths=data_paths,
             num_shards=10,
             valid_shards=2,
@@ -224,7 +224,7 @@ class TestNano3DataPrepTrainIntegration:
             seed=42,
         )
 
-        result2 = _distribute_shards_to_splits(
+        result2 = distribute_shards_to_splits(
             data_paths=data_paths,
             num_shards=10,
             valid_shards=2,
@@ -249,7 +249,7 @@ class TestWandbArtifactIntegration:
 
         This is the key integration test for the data_prep -> train contract.
         """
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -341,7 +341,7 @@ class TestWandbArtifactIntegration:
 
     def test_artifact_without_blend_json_should_fail_gracefully(self, monkeypatch, tmp_path):
         """Test that missing blend.json is detected early with clear error."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -387,7 +387,7 @@ class TestWandbArtifactIntegration:
 
     def test_wandb_artifact_resolution_for_train(self, monkeypatch, tmp_path):
         """Test ${art:data,path} resolver works with train.py config pattern."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 

--- a/tests/recipes/nano3/stage1_sft/test_data_prep_train_integration.py
+++ b/tests/recipes/nano3/stage1_sft/test_data_prep_train_integration.py
@@ -386,7 +386,7 @@ class TestOmegaConfResolverIntegration:
 
     def test_art_resolver_resolves_data_path(self, monkeypatch, tmp_path):
         """Test ${art:data,path} resolves to artifact download path."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -428,7 +428,7 @@ class TestOmegaConfResolverIntegration:
 
     def test_art_resolver_resolves_pack_size(self, monkeypatch, tmp_path):
         """Test ${art:data,pack_size} resolves to artifact pack_size field."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -479,7 +479,7 @@ class TestOmegaConfResolverIntegration:
 
     def test_art_resolver_resolves_training_path(self, monkeypatch, tmp_path):
         """Test ${art:data,training_path} resolves to training file path."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -531,27 +531,27 @@ class TestOmegaConfResolverIntegration:
 
     def test_run_wandb_project_interpolation(self, monkeypatch, tmp_path):
         """Test ${run.wandb.project} resolves from run section."""
-        from nemotron.kit.cli.config import _resolve_run_interpolations
+        from nemo_runspec.utils import resolve_run_interpolations
 
         config_dict = {
             "logger": {"wandb_project": "${run.wandb.project}"},
         }
         run_section = {"wandb": {"project": "test-project", "entity": "test-entity"}}
 
-        result = _resolve_run_interpolations(config_dict, run_section)
+        result = resolve_run_interpolations(config_dict, run_section)
 
         assert result["logger"]["wandb_project"] == "test-project"
 
     def test_run_wandb_entity_interpolation(self, monkeypatch, tmp_path):
         """Test ${run.wandb.entity} resolves from run section."""
-        from nemotron.kit.cli.config import _resolve_run_interpolations
+        from nemo_runspec.utils import resolve_run_interpolations
 
         config_dict = {
             "logger": {"wandb_entity": "${run.wandb.entity}"},
         }
         run_section = {"wandb": {"project": "test-project", "entity": "test-entity"}}
 
-        result = _resolve_run_interpolations(config_dict, run_section)
+        result = resolve_run_interpolations(config_dict, run_section)
 
         assert result["logger"]["wandb_entity"] == "test-entity"
 
@@ -561,7 +561,7 @@ class TestWandbArtifactIntegration:
 
     def test_wandb_artifact_resolution_for_sft_train(self, monkeypatch, tmp_path):
         """Test ${art:data,path} resolver works with SFT train.py config pattern."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -678,7 +678,7 @@ class TestSFTDataPrepTrainContract:
 
     def test_full_data_prep_to_train_flow(self, monkeypatch, tmp_path):
         """Test complete flow: data_prep output -> train consumption."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 

--- a/tests/recipes/nano3/stage2_rl/test_data_prep_train_integration.py
+++ b/tests/recipes/nano3/stage2_rl/test_data_prep_train_integration.py
@@ -36,7 +36,7 @@ from omegaconf import OmegaConf
 
 from nemotron.kit import SplitJsonlDataArtifact
 
-from nemotron.data_prep.hf_placeholder import (
+from nemotron.data_prep.utils.hf_placeholder import (
     TARGET_DATASETS,
     HFPlaceholderResolver,
     get_nested_value,
@@ -364,7 +364,7 @@ class TestTransformIntegration:
     def test_placeholder_record_with_mock_resolver(self):
         """Test placeholder record resolution with a mock resolver."""
         from nemotron.data_prep.formats.transforms import resolve_hf_placeholders
-        from nemotron.data_prep.hf_placeholder import HFPlaceholderResolver, PlaceholderConfig
+        from nemotron.data_prep.utils.hf_placeholder import HFPlaceholderResolver, PlaceholderConfig
 
         # Create a mock dataset (simple dict-based mock)
         class MockDataset:
@@ -414,7 +414,7 @@ class TestTransformIntegration:
 
     def test_skywork_template_resolution(self):
         """Test Skywork-style {question} template resolution."""
-        from nemotron.data_prep.hf_placeholder import HFPlaceholderResolver, PlaceholderConfig
+        from nemotron.data_prep.utils.hf_placeholder import HFPlaceholderResolver, PlaceholderConfig
 
         class MockDataset:
             def __init__(self, data):
@@ -623,7 +623,7 @@ class TestWandbArtifactIntegration:
 
         This is the key integration test for the data_prep -> train contract.
         """
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -702,7 +702,7 @@ class TestWandbArtifactIntegration:
 
     def test_wandb_artifact_resolution_for_train(self, monkeypatch, tmp_path):
         """Test ${art:data,path} resolver works with train.py config pattern."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 
@@ -750,7 +750,7 @@ class TestWandbArtifactIntegration:
 
     def test_artifact_without_manifest_should_fail_gracefully(self, monkeypatch, tmp_path):
         """Test that missing manifest.json is detected early with clear error."""
-        from nemotron.kit import resolvers
+        from nemo_runspec.config import resolvers
 
         resolvers.clear_artifact_cache()
 


### PR DESCRIPTION
Addresses the test-collection errors in #213.

A bunch of test modules still imported from paths that went away in the `kit` -> `nemo_runspec` move and the data_prep submodule reshuffle, so `pytest` errored out at collection. This repoints them: `data_prep.filesystem` -> `data_prep.utils.filesystem`, `data_prep.stage_keys` -> `data_prep.observability.stage_keys`, `data_prep.hf_placeholder` -> `data_prep.utils.hf_placeholder`, `kit.cli.utils` -> `nemo_runspec.utils`, and `from nemotron.kit import resolvers` -> `from nemo_runspec.config import resolvers`. Two helpers also went from private to public, so `_distribute_shards_to_splits` and `_resolve_run_interpolations` now point at the public `distribute_shards_to_splits` / `resolve_run_interpolations`.

I checked each symbol exists at its new home by parsing the source (couldn't run the full suite locally since the package pulls in cosmos_xenna). One test I left alone: `stage2_rl`'s `test_split_ratios_validation` imports `RLMergeDataPrepConfig`, which looks removed in the recipe refactor (the current `RLDataPrepConfig` has no ratio fields). Happy to drop or update it once you confirm what replaced it. The lint/pre-commit half of #213 is separate and not touched here.
