### PR TITLE
docs: fix typos in README and training docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The catalog covers the full training lifecycle.
 
 ## Training Recipes
 
-The Nemotron respository provides reproducible training pipelines from raw data to deployment-ready models. These implementations reflect how large language models are actually trained: careful experimentation, validation gates, and systematic optimization.
+The Nemotron repository provides reproducible training pipelines from raw data to deployment-ready models. These implementations reflect how large language models are actually trained: careful experimentation, validation gates, and systematic optimization.
 
 ### Why Complete Pipelines?
 

--- a/docs/train-models/getting-started.md
+++ b/docs/train-models/getting-started.md
@@ -12,7 +12,7 @@ The goal is to validate end-to-end execution, NeMo Run, and your environment pro
   - `HF_TOKEN`
   - `WANDB_API_KEY`
   - `NVIDIA_API_KEY`
-- You ran `lep login` after syncronizing dependencies and are logged into Lepton.
+- You ran `lep login` after synchronizing dependencies and are logged into Lepton.
 
 The preceding list applies to the steps on this page.
 Refer to [](./index.md#limitations-and-restrictions) for information about supported environments.

--- a/usage-cookbook/Nemotron-3-Ultra/lora-text2sql/nemo-megatron-bridge/README.md
+++ b/usage-cookbook/Nemotron-3-Ultra/lora-text2sql/nemo-megatron-bridge/README.md
@@ -29,7 +29,7 @@ moving on.
 ## Prerequisites
 
 - A SLURM multi-node cluster with at least 48 GPUs (H100 and above) with Pyxis/enroot (`srun --container-image=...`). **This notebook was tested on GB200 nodes (4 GPUs/node).**
-- The **Nemotron-3 Ultra checkpont** downloaded to a shared path (accessible to all nodes, such as lustre) — set as `HF_MODEL_PATH`.
+- The **Nemotron-3 Ultra checkpoint** downloaded to a shared path (accessible to all nodes, such as lustre) — set as `HF_MODEL_PATH`.
 - A **Hugging Face token** placed at `${HF_HOME}/token`.
 - This notebook directory on a **shared filesystem** the compute nodes can mount.
 - A working **container image**. The notebook ships with a placeholder


### PR DESCRIPTION
Fixes minor spelling typos in documentation:
     - `respository` → `repository` in README.md
     - `syncronizing` → `synchronizing` in
   docs/train-models/getting-started.md
     - `checkpont` → `checkpoint` in
   usage-cookbook/Nemotron-3-Ultra/lora-text2sql/nemo-megatron-bridge/README
   .md