### PR TITLE
docs: fix broken examples link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ When contributing a new recipe:
 
 ## Questions?
 
-- Review examples in `examples/`
+- Review examples in [`usage-cookbook/`](./usage-cookbook/)
 - Open an issue for discussions
 
 ---


### PR DESCRIPTION
The CONTRIBUTING.md file referenced an `examples/` directory that does
   not exist in the repository. Update it to point to `usage-cookbook/`,
   which contains the project's example cookbooks.