### PR TITLE
ci: use NVIDIA inference for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,8 +12,9 @@ permissions:
 
 jobs:
   claude-review:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.88.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
     with:
+      model: ${{ vars.CLAUDE_MODEL }}
       prompt: |
         You are doing a light code review. Keep it concise and actionable.
 
@@ -35,4 +36,5 @@ jobs:
         It's perfectly acceptable to not have anything to comment on.
         If you do not have anything to comment on, post "LGTM".
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      NVIDIA_INFERENCE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+      NVIDIA_INFERENCE_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}


### PR DESCRIPTION
## Summary
- Bump Claude review to `NVIDIA-NeMo/FW-CI-templates@v1.7.0`.
- Pass `vars.CLAUDE_MODEL` to the reusable workflow.
- Pass `secrets.NVIDIA_INFERENCE_URL` and `secrets.NVIDIA_INFERENCE_KEY` instead of `secrets.ANTHROPIC_API_KEY`.

## Validation
- Parsed `.github/workflows/claude-review.yml` with Ruby YAML loader.
- Confirmed no remaining `ANTHROPIC_API_KEY`, `claude-opus-4-6`, or pre-`v1.7.0` `_claude_review.yml` references in this workflow.

Linear: AUT-644