### PR TITLE
Add CODE_OF_CONDUCT.md and GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Nemotron
+title: "[Bug] "
+labels: bug
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## Reproduction Steps
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- OS: [e.g., Ubuntu 22.04]
+- Python version: [e.g., 3.10.12]
+- Nemotron version: [e.g., 0.1.0 or commit hash]
+- GPU/CUDA: [e.g., H100 / CUDA 12.4, or "N/A"]
+- Relevant dependencies: [e.g., megatron-bridge version, NeMo-RL version]
+
+## Additional Context
+
+Logs, screenshots, or any other context that helps diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest a feature or enhancement for Nemotron
+title: "[Feature] "
+labels: enhancement
+---
+
+## Feature Description
+
+A clear and concise description of the feature or enhancement you'd like.
+
+## Motivation
+
+Why is this feature useful? What problem does it solve?
+
+## Proposed Solution
+
+Describe how you'd like this feature to work. If you have a specific API or CLI
+shape in mind, include a short example.
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've considered.
+
+## Additional Context
+
+Links, references, or any other context that supports the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## Description
+
+Briefly describe what this PR does and why.
+
+## Related Issue
+
+Fixes #(issue number) <!-- or: Related to #(issue number) -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Test improvement
+- [ ] New training recipe or step
+
+## Changes Made
+
+-
+-
+-
+
+## Testing
+
+Describe how you tested these changes. Include commands if applicable.
+
+```bash
+# Example:
+uv run pytest tests/
+```
+
+## Checklist
+
+- [ ] My code follows the existing style conventions (ruff + ruff-format)
+- [ ] I have added type hints and docstrings where applicable
+- [ ] I have added tests for new functionality
+- [ ] All existing and new tests pass
+- [ ] I have updated documentation where needed
+- [ ] My commits are signed off (`git commit -s`) per the DCO
+
+## Additional Notes
+
+Any other context reviewers should know.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best for the overall community, not just us as
+  individuals
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+nemotron-conduct@nvidia.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
## Description

This PR adds standard community files that were missing from the repository:

- **[CODE_OF_CONDUCT.md](cci:7://file:///home/m-h-jishan/CascadeProjects/Nemotron/CODE_OF_CONDUCT.md:0:0-0:0)** — Contributor Covenant 2.1, the widely adopted standard used by NVIDIA and most open-source projects
- **[.github/ISSUE_TEMPLATE/bug_report.md](cci:7://file:///home/m-h-jishan/CascadeProjects/Nemotron/.github/ISSUE_TEMPLATE/bug_report.md:0:0-0:0)** — Bug report template with ML/GPU-specific environment fields (CUDA, GPU, megatron-bridge version, etc.)
- **[.github/ISSUE_TEMPLATE/feature_request.md](cci:7://file:///home/m-h-jishan/CascadeProjects/Nemotron/.github/ISSUE_TEMPLATE/feature_request.md:0:0-0:0)** — Feature request template with motivation, proposed solution, and alternatives sections
- **[.github/PULL_REQUEST_TEMPLATE.md](cci:7://file:///home/m-h-jishan/CascadeProjects/Nemotron/.github/PULL_REQUEST_TEMPLATE.md:0:0-0:0)** — PR template with change-type checkboxes, testing section, and a DCO sign-off checklist matching the requirement in [CONTRIBUTING.md](cci:7://file:///home/m-h-jishan/CascadeProjects/Nemotron/CONTRIBUTING.md:0:0-0:0)

## Type of Change

- [x] Documentation update
- [x] Community / repo infrastructure

## Checklist

- [x] My commits are signed off (`git commit -s`) per the DCO