### PR TITLE
Fix qrel source identifier collisions

### DIFF
--- a/src/nemotron/recipes/embed/stage1_data_prep/scripts/convert_to_retriever_data.py
+++ b/src/nemotron/recipes/embed/stage1_data_prep/scripts/convert_to_retriever_data.py
@@ -230,13 +230,16 @@ def get_corpus_id(text: str) -> str:
     return 'd_' + hex_dig[:16]
 
 
-def extract_base_filename(file_path: str) -> str:
+def normalize_file_path(file_path: str) -> str:
+    """Return a stable path key without discarding any part of the filename.
+
+    ``file_name`` values are source identifiers, not necessarily conventional
+    filenames.  In particular, values such as ``research.nvidia.com_...`` do
+    not have a file extension: using :func:`os.path.splitext` on them truncates
+    every identifier to ``research.nvidia`` and causes chunk mappings to
+    overwrite one another.
     """
-    Extract base filename from a file path.
-    """
-    base_name = os.path.basename(file_path)
-    base_name_no_ext = os.path.splitext(base_name)[0]
-    return base_name_no_ext
+    return os.path.normpath(file_path.replace("\\", "/")).replace("\\", "/")
 
 
 def normalize_file_name(file_name) -> List[str]:
@@ -264,7 +267,7 @@ def get_file_identifier(file_name_list: List[str]) -> str:
     """
     Get a canonical string identifier from a file_name list.
     
-    For single-doc (1-element list), returns the base filename.
+    For single-doc (1-element list), returns the full normalized source path.
     For multi-doc (2+ elements), returns a hash of the sorted paths.
     
     Args:
@@ -276,9 +279,10 @@ def get_file_identifier(file_name_list: List[str]) -> str:
     if not file_name_list:
         return ""
     if len(file_name_list) == 1:
-        return extract_base_filename(file_name_list[0])
+        return normalize_file_path(file_name_list[0])
     # Multi-doc: use hash of sorted paths for consistent identifier
-    return hashlib.md5("||".join(sorted(file_name_list)).encode()).hexdigest()[:16]
+    normalized_paths = sorted(normalize_file_path(path) for path in file_name_list)
+    return hashlib.md5("||".join(normalized_paths).encode()).hexdigest()[:16]
 
 
 def load_generated_json_files(input_path: str) -> pd.DataFrame:
@@ -364,10 +368,10 @@ def build_corpus_and_mappings(
     Returns:
         Tuple of:
         - corpus: Dict mapping text -> corpus_id (deduplicated by text content)
-        - chunk_mapping: Dict mapping (base_filename, chunk_id) -> text
+        - chunk_mapping: Dict mapping (file_identifier, chunk_id) -> text
     """
     corpus = {}  # text -> corpus_id
-    chunk_mapping = {}  # (base_filename, chunk_id) -> text
+    chunk_mapping = {}  # (file_identifier, chunk_id) -> text
     
     print("Building corpus and chunk mappings...")
     
@@ -481,7 +485,7 @@ def generate_training_set(
     
     Args:
         corpus: Dict mapping text -> corpus_id
-        chunk_mapping: Dict mapping (base_filename, chunk_id) -> text
+        chunk_mapping: Dict mapping (file_identifier, chunk_id) -> text
         train_df: DataFrame with QA pairs
         output_dir: Output directory path
         corpus_id: Corpus identifier
@@ -598,7 +602,7 @@ def generate_eval_set(
     
     Args:
         corpus: Dict mapping text -> corpus_id
-        chunk_mapping: Dict mapping (base_filename, chunk_id) -> text
+        chunk_mapping: Dict mapping (file_identifier, chunk_id) -> text
         eval_df: DataFrame with QA pairs
         output_dir: Output directory path
         max_pos_docs: Maximum number of positive docs per query
@@ -944,4 +948,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/src/nemotron/recipes/embed/stage1_data_prep/scripts/convert_to_retriever_data.py
+++ b/src/nemotron/recipes/embed/stage1_data_prep/scripts/convert_to_retriever_data.py
@@ -28,20 +28,20 @@ Usage:
     python convert_to_retriever_data.py ./generated_output --corpus-id my_corpus --quality-threshold 8.0
 """
 
+import argparse
+import glob
+import hashlib
 import json
 import os
-import argparse
-import hashlib
-import glob
 import random
-from typing import Dict, List, Tuple, Any
-import pandas as pd
+from typing import Any
+
 import numpy as np
+import pandas as pd
 
 
 def filter_qa_pairs_by_quality(
-    generated_df: pd.DataFrame,
-    quality_threshold: float = 7.0
+    generated_df: pd.DataFrame, quality_threshold: float = 7.0
 ) -> tuple[pd.DataFrame, list[dict]]:
     """Filter deduplicated_qa_pairs based on qa_evaluations scores.
 
@@ -69,13 +69,13 @@ def filter_qa_pairs_by_quality(
     skipped_files = []  # Track files skipped due to data integrity issues
 
     for _, row in generated_df.iterrows():
-        file_name = row.get('file_name', 'unknown')
+        file_name = row.get("file_name", "unknown")
 
         # Get deduplicated QA pairs
-        deduplicated_qa_pairs = row.get('deduplicated_qa_pairs')
+        deduplicated_qa_pairs = row.get("deduplicated_qa_pairs")
 
         # Get QA evaluations
-        qa_evaluations = row.get('qa_evaluations')
+        qa_evaluations = row.get("qa_evaluations")
 
         # Handle case where deduplicated_qa_pairs might be None
         if deduplicated_qa_pairs is None:
@@ -95,9 +95,9 @@ def filter_qa_pairs_by_quality(
         evaluation_scores = []
         if qa_evaluations is not None:
             if isinstance(qa_evaluations, dict):
-                evaluations_list = qa_evaluations.get('evaluations', [])
+                evaluations_list = qa_evaluations.get("evaluations", [])
             else:
-                evaluations_list = getattr(qa_evaluations, 'evaluations', [])
+                evaluations_list = getattr(qa_evaluations, "evaluations", [])
 
             # Convert numpy array to list if needed
             if isinstance(evaluations_list, np.ndarray):
@@ -106,18 +106,18 @@ def filter_qa_pairs_by_quality(
             # Extract overall scores
             for eval_item in evaluations_list:
                 if isinstance(eval_item, dict):
-                    overall = eval_item.get('overall', {})
+                    overall = eval_item.get("overall", {})
                     if isinstance(overall, dict):
-                        score = overall.get('score', 0)
+                        score = overall.get("score", 0)
                     else:
-                        score = getattr(overall, 'score', 0)
+                        score = getattr(overall, "score", 0)
                 else:
-                    overall = getattr(eval_item, 'overall', None)
+                    overall = getattr(eval_item, "overall", None)
                     if overall is not None:
                         if isinstance(overall, dict):
-                            score = overall.get('score', 0)
+                            score = overall.get("score", 0)
                         else:
-                            score = getattr(overall, 'score', 0)
+                            score = getattr(overall, "score", 0)
                     else:
                         score = 0
                 evaluation_scores.append(score)
@@ -129,7 +129,7 @@ def filter_qa_pairs_by_quality(
                 f"but qa_evaluations has {len(evaluation_scores)} items"
             )
             print(f"Warning: Skipping {file_name} - data integrity error: {reason}")
-            skipped_files.append({'file_name': file_name, 'reason': reason})
+            skipped_files.append({"file_name": file_name, "reason": reason})
             continue
 
         # Filter QA pairs based on quality threshold
@@ -147,17 +147,17 @@ def filter_qa_pairs_by_quality(
                 else:
                     # Handle Pydantic model objects by converting to dict
                     qa_pair_with_metadata = {
-                        'question': getattr(qa_pair, 'question', ''),
-                        'answer': getattr(qa_pair, 'answer', ''),
-                        'query_type': getattr(qa_pair, 'query_type', ''),
-                        'reasoning_type': getattr(qa_pair, 'reasoning_type', ''),
-                        'question_complexity': getattr(qa_pair, 'question_complexity', 0),
-                        'segment_ids': getattr(qa_pair, 'segment_ids', []),
-                        'hop_count': getattr(qa_pair, 'hop_count', 1),
-                        'hop_contexts': getattr(qa_pair, 'hop_contexts', []),
+                        "question": getattr(qa_pair, "question", ""),
+                        "answer": getattr(qa_pair, "answer", ""),
+                        "query_type": getattr(qa_pair, "query_type", ""),
+                        "reasoning_type": getattr(qa_pair, "reasoning_type", ""),
+                        "question_complexity": getattr(qa_pair, "question_complexity", 0),
+                        "segment_ids": getattr(qa_pair, "segment_ids", []),
+                        "hop_count": getattr(qa_pair, "hop_count", 1),
+                        "hop_contexts": getattr(qa_pair, "hop_contexts", []),
                     }
-                qa_pair_with_metadata['file_name'] = file_name
-                qa_pair_with_metadata['quality_score'] = quality_score
+                qa_pair_with_metadata["file_name"] = file_name
+                qa_pair_with_metadata["quality_score"] = quality_score
                 all_filtered_qa_pairs.append(qa_pair_with_metadata)
             else:
                 filtered_pairs += 1
@@ -172,45 +172,46 @@ def filter_qa_pairs_by_quality(
     print(f"  Remaining high-quality pairs: {len(filtered_df)}")
     print(f"  Files skipped due to data issues: {len(skipped_files)}")
     if total_pairs > 0:
-        print(f"  Retention rate: {len(filtered_df)/total_pairs*100:.1f}%")
+        print(f"  Retention rate: {len(filtered_df) / total_pairs * 100:.1f}%")
     else:
         print("  Retention rate: 0%")
 
     return filtered_df, skipped_files
 
 
-def filter_mismatched_records(
-    records: List[Dict[str, Any]]
-) -> Tuple[List[Dict[str, Any]], int]:
+def filter_mismatched_records(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
     """
     Filter out records where qa_evaluations.evaluations and deduplicated_qa_pairs
     have different sizes.
-    
+
     Returns:
         - Filtered records
         - Count of dropped records
     """
     filtered = []
     dropped_count = 0
-    
+
     for record in records:
         # Get sizes, defaulting to 0 if missing
         qa_evals = record.get("qa_evaluations", {}).get("evaluations", [])
         dedup_pairs = record.get("deduplicated_qa_pairs", [])
-        
+
         eval_count = len(qa_evals)
         pairs_count = len(dedup_pairs)
-        
+
         if eval_count == pairs_count:
             filtered.append(record)
         else:
             dropped_count += 1
             file_name = record.get("file_name", "unknown")
             # Handle both list and string file_name for display
-            display_name = file_name if isinstance(file_name, str) else ", ".join(file_name) if file_name else "unknown"
-            print(f"  Dropping record '{display_name}': "
-                  f"qa_evaluations={eval_count}, deduplicated_qa_pairs={pairs_count}")
-    
+            display_name = (
+                file_name if isinstance(file_name, str) else ", ".join(file_name) if file_name else "unknown"
+            )
+            print(
+                f"  Dropping record '{display_name}': qa_evaluations={eval_count}, deduplicated_qa_pairs={pairs_count}"
+            )
+
     return filtered, dropped_count
 
 
@@ -218,16 +219,16 @@ def get_corpus_id(text: str) -> str:
     """
     Generate hash-based corpus ID from text.
     Uses SHA256 hash with 16-character prefix.
-    
+
     Args:
         text: Text content to hash
-        
+
     Returns:
         Corpus ID in format 'd_<16-char-hash>'
     """
     hash_object = hashlib.sha256(text.encode())
     hex_dig = hash_object.hexdigest()
-    return 'd_' + hex_dig[:16]
+    return "d_" + hex_dig[:16]
 
 
 def normalize_file_path(file_path: str) -> str:
@@ -242,16 +243,16 @@ def normalize_file_path(file_path: str) -> str:
     return os.path.normpath(file_path.replace("\\", "/")).replace("\\", "/")
 
 
-def normalize_file_name(file_name) -> List[str]:
+def normalize_file_name(file_name) -> list[str]:
     """
     Normalize file_name to list format.
-    
+
     Provides backward compatibility for old data where file_name was a string
     (single-doc mode). New data always uses list format.
-    
+
     Args:
         file_name: Either a string (old format) or list of strings (new format)
-        
+
     Returns:
         List of file name strings
     """
@@ -263,16 +264,16 @@ def normalize_file_name(file_name) -> List[str]:
         return [str(file_name)]
 
 
-def get_file_identifier(file_name_list: List[str]) -> str:
+def get_file_identifier(file_name_list: list[str]) -> str:
     """
     Get a canonical string identifier from a file_name list.
-    
+
     For single-doc (1-element list), returns the full normalized source path.
     For multi-doc (2+ elements), returns a hash of the sorted paths.
-    
+
     Args:
         file_name_list: List of file names in the bundle
-        
+
     Returns:
         String identifier for use in chunk mappings
     """
@@ -288,22 +289,22 @@ def get_file_identifier(file_name_list: List[str]) -> str:
 def load_generated_json_files(input_path: str) -> pd.DataFrame:
     """
     Load generated JSON data from either a single file or a folder of batch files.
-    
+
     Args:
         input_path: Path to either:
             - A single merged JSON file
             - A folder containing generated_batch*.json files
-        
+
     Returns:
         Combined DataFrame with all records
     """
     all_records = []
-    
+
     # Check if input is a file or directory
     if os.path.isfile(input_path):
         # Single file mode (merged JSON)
         print(f"Loading single JSON file: {input_path}")
-        with open(input_path, 'r', encoding='utf-8') as f:
+        with open(input_path, encoding="utf-8") as f:
             content = f.read()
         try:
             records = json.loads(content)
@@ -320,51 +321,49 @@ def load_generated_json_files(input_path: str) -> pd.DataFrame:
                 all_records.append(records)
     else:
         # Folder mode (batch files)
-        json_files = sorted(glob.glob(os.path.join(input_path, 'generated_batch*.json')))
-        
+        json_files = sorted(glob.glob(os.path.join(input_path, "generated_batch*.json")))
+
         if not json_files:
-            json_files = sorted(glob.glob(os.path.join(input_path, '*.json')))
-        
+            json_files = sorted(glob.glob(os.path.join(input_path, "*.json")))
+
         if not json_files:
             raise ValueError(f"No JSON files found in {input_path}")
-        
+
         print(f"Found {len(json_files)} JSON files")
-        
+
         for json_file in json_files:
             print(f"  Loading: {json_file}")
-            with open(json_file, 'r', encoding='utf-8') as f:
+            with open(json_file, encoding="utf-8") as f:
                 records = json.load(f)
                 if isinstance(records, list):
                     all_records.extend(records)
                 else:
                     all_records.append(records)
-    
+
     # Normalize file_name to list format (backward compat for old string format)
     print("Normalizing file_name fields...")
     for record in all_records:
-        if 'file_name' in record:
-            record['file_name'] = normalize_file_name(record['file_name'])
-    
+        if "file_name" in record:
+            record["file_name"] = normalize_file_name(record["file_name"])
+
     # Filter mismatched records
     print("Filtering mismatched records...")
     all_records, dropped_count = filter_mismatched_records(all_records)
     if dropped_count > 0:
         print(f"Dropped {dropped_count} records with mismatched qa_evaluations/deduplicated_qa_pairs sizes")
-    
+
     df = pd.DataFrame(all_records)
     print(f"Loaded {len(df)} total records")
     return df
 
 
-def build_corpus_and_mappings(
-    generated_df: pd.DataFrame
-) -> Tuple[Dict[str, str], Dict[Tuple[str, int], str]]:
+def build_corpus_and_mappings(generated_df: pd.DataFrame) -> tuple[dict[str, str], dict[tuple[str, int], str]]:
     """
     Build deduplicated corpus and chunk mappings from generated data.
-    
+
     Args:
         generated_df: DataFrame with 'file_name' and 'chunks' columns
-        
+
     Returns:
         Tuple of:
         - corpus: Dict mapping text -> corpus_id (deduplicated by text content)
@@ -372,117 +371,113 @@ def build_corpus_and_mappings(
     """
     corpus = {}  # text -> corpus_id
     chunk_mapping = {}  # (file_identifier, chunk_id) -> text
-    
+
     print("Building corpus and chunk mappings...")
-    
+
     for _, row in generated_df.iterrows():
-        file_name_list = row.get('file_name', [])
-        chunks = row.get('chunks', [])
-        
+        file_name_list = row.get("file_name", [])
+        chunks = row.get("chunks", [])
+
         if not chunks or not file_name_list:
             continue
-        
+
         # Get canonical identifier for this file/bundle
         file_identifier = get_file_identifier(file_name_list)
-        
+
         # Handle numpy arrays
-        if hasattr(chunks, 'tolist'):
+        if hasattr(chunks, "tolist"):
             chunks = chunks.tolist()
-        
+
         for chunk in chunks:
             if isinstance(chunk, dict):
-                chunk_id = chunk.get('chunk_id')
-                text = chunk.get('text', '')
+                chunk_id = chunk.get("chunk_id")
+                text = chunk.get("text", "")
             else:
-                chunk_id = getattr(chunk, 'chunk_id', None)
-                text = getattr(chunk, 'text', '')
-            
+                chunk_id = getattr(chunk, "chunk_id", None)
+                text = getattr(chunk, "text", "")
+
             if chunk_id is None or not text:
                 continue
-            
+
             # Store mapping using canonical file identifier
             chunk_mapping[(file_identifier, chunk_id)] = text
-            
+
             # Add to deduplicated corpus
             if text not in corpus:
                 corpus[text] = get_corpus_id(text)
-    
+
     print(f"Built corpus with {len(corpus)} unique documents from {len(chunk_mapping)} total chunks")
     return corpus, chunk_mapping
 
 
 def create_train_val_test_split(
-    filtered_qa_df: pd.DataFrame,
-    train_ratio: float,
-    val_ratio: float,
-    seed: int
-) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    filtered_qa_df: pd.DataFrame, train_ratio: float, val_ratio: float, seed: int
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     Split filtered QA pairs into train, val, and test sets by file/bundle.
-    
+
     Args:
         filtered_qa_df: DataFrame with filtered QA pairs
         train_ratio: Ratio of files for training (e.g., 0.8 for 80%)
         val_ratio: Ratio of files for validation (e.g., 0.1 for 10%)
         seed: Random seed for reproducibility
-        
+
     Returns:
         Tuple of (train_df, val_df, test_df)
     """
     random.seed(seed)
-    
+
     # Validate ratios
     test_ratio = 1.0 - train_ratio - val_ratio
     if test_ratio < 0:
         raise ValueError(f"train_ratio ({train_ratio}) + val_ratio ({val_ratio}) must be <= 1.0")
-    
+
     # Get unique files/bundles - convert lists to tuples for hashability
     # file_name is now always a list (e.g., ['doc.txt'] or ['a.txt', 'b.txt'])
-    unique_file_tuples = sorted(set(
-        tuple(f) if isinstance(f, list) else (f,) 
-        for f in filtered_qa_df['file_name']
-    ))
-    
+    unique_file_tuples = sorted(set(tuple(f) if isinstance(f, list) else (f,) for f in filtered_qa_df["file_name"]))
+
     # Shuffle files
     random.shuffle(unique_file_tuples)
-    
+
     n_train = int(len(unique_file_tuples) * train_ratio)
     n_val = int(len(unique_file_tuples) * val_ratio)
-    
+
     train_files = set(unique_file_tuples[:n_train])
-    val_files = set(unique_file_tuples[n_train:n_train + n_val])
-    test_files = set(unique_file_tuples[n_train + n_val:])
-    
+    val_files = set(unique_file_tuples[n_train : n_train + n_val])
+    test_files = set(unique_file_tuples[n_train + n_val :])
+
     # Helper to check if a file_name belongs to a set of tuples
     def file_in_set(file_name, file_set):
         file_tuple = tuple(file_name) if isinstance(file_name, list) else (file_name,)
         return file_tuple in file_set
-    
-    train_df = filtered_qa_df[filtered_qa_df['file_name'].apply(lambda f: file_in_set(f, train_files))]
-    val_df = filtered_qa_df[filtered_qa_df['file_name'].apply(lambda f: file_in_set(f, val_files))]
-    test_df = filtered_qa_df[filtered_qa_df['file_name'].apply(lambda f: file_in_set(f, test_files))]
-    
-    print(f"Split: {len(train_files)} train files/bundles ({len(train_df)} QA pairs), "
-          f"{len(val_files)} val files/bundles ({len(val_df)} QA pairs), "
-          f"{len(test_files)} test files/bundles ({len(test_df)} QA pairs)")
-    
+
+    train_df = filtered_qa_df[filtered_qa_df["file_name"].apply(lambda f: file_in_set(f, train_files))]
+    val_df = filtered_qa_df[filtered_qa_df["file_name"].apply(lambda f: file_in_set(f, val_files))]
+    test_df = filtered_qa_df[filtered_qa_df["file_name"].apply(lambda f: file_in_set(f, test_files))]
+
+    print(
+        f"Split: {len(train_files)} train files/bundles ({len(train_df)} QA pairs), "
+        f"{len(val_files)} val files/bundles ({len(val_df)} QA pairs), "
+        f"{len(test_files)} test files/bundles ({len(test_df)} QA pairs)"
+    )
+
     return train_df, val_df, test_df
 
 
 def generate_training_set(
-    corpus: Dict[str, str],
-    chunk_mapping: Dict[Tuple[str, int], str],
+    corpus: dict[str, str],
+    chunk_mapping: dict[tuple[str, int], str],
     train_df: pd.DataFrame,
     output_dir: str,
     corpus_id: str,
     max_pos_docs: int = 5,
-    output_filename: str = 'train.json',
-    set_name: str = 'training',
-    write_corpus: bool = True
+    output_filename: str = "train.json",
+    set_name: str = "training",
+    write_corpus: bool = True,
 ) -> None:
     """
     Generate training/validation set in retriever training format.
-    
+
     Args:
         corpus: Dict mapping text -> corpus_id
         chunk_mapping: Dict mapping (file_identifier, chunk_id) -> text
@@ -495,111 +490,107 @@ def generate_training_set(
         write_corpus: Whether to write corpus parquet and metadata files (default: True)
     """
     print(f"Generating {set_name} set...")
-    
+
     # Create output directories
-    corpus_dir = os.path.join(output_dir, 'corpus')
+    corpus_dir = os.path.join(output_dir, "corpus")
     os.makedirs(corpus_dir, exist_ok=True)
-    
+
     training_data = []
     question_counter = 0
     skipped_queries = 0
     skipped_too_many_pos = 0
-    
+
     for _, qa_pair in train_df.iterrows():
-        file_name_list = qa_pair.get('file_name', [])
+        file_name_list = qa_pair.get("file_name", [])
         # file_name is now always a list; get canonical identifier
-        file_identifier = get_file_identifier(file_name_list) if file_name_list else ''
-        segment_ids = qa_pair.get('segment_ids', [])
-        question = qa_pair.get('question', '')
-        
+        file_identifier = get_file_identifier(file_name_list) if file_name_list else ""
+        segment_ids = qa_pair.get("segment_ids", [])
+        question = qa_pair.get("question", "")
+
         if not question:
             skipped_queries += 1
             continue
-        
+
         # Handle numpy arrays
-        if hasattr(segment_ids, 'tolist'):
+        if hasattr(segment_ids, "tolist"):
             segment_ids = segment_ids.tolist()
-        
+
         # Skip queries with too many positive docs
         if len(segment_ids) > max_pos_docs:
             skipped_too_many_pos += 1
             continue
-        
+
         # Get corpus IDs for all segments
         pos_docs = []
         all_segments_exist = True
-        
+
         for segment_id in segment_ids:
             key = (file_identifier, segment_id)
             if key not in chunk_mapping:
                 all_segments_exist = False
                 break
-            
+
             text = chunk_mapping[key]
             corpus_doc_id = corpus[text]
-            pos_docs.append({'id': corpus_doc_id})
-        
+            pos_docs.append({"id": corpus_doc_id})
+
         if not all_segments_exist or not pos_docs:
             skipped_queries += 1
             continue
-        
-        training_data.append({
-            'question_id': f'q{question_counter}',
-            'question': question,
-            'corpus_id': corpus_id,
-            'pos_doc': pos_docs,
-            'neg_doc': []
-        })
+
+        training_data.append(
+            {
+                "question_id": f"q{question_counter}",
+                "question": question,
+                "corpus_id": corpus_id,
+                "pos_doc": pos_docs,
+                "neg_doc": [],
+            }
+        )
         question_counter += 1
-    
+
     print(f"  Generated {len(training_data)} {set_name} queries")
     if skipped_queries > 0:
         print(f"  Skipped {skipped_queries} queries (missing segments or empty question)")
     if skipped_too_many_pos > 0:
         print(f"  Skipped {skipped_too_many_pos} queries (exceeded max_pos_docs={max_pos_docs})")
-    
+
     # Write output JSON file
     # Use relative path for corpus so data is portable across machines/containers
     train_json_path = os.path.join(output_dir, output_filename)
-    with open(train_json_path, 'w', encoding='utf-8') as f:
-        json.dump({
-            'corpus': {'path': './corpus/'},
-            'data': training_data
-        }, f, indent=2, sort_keys=False)
-    
+    with open(train_json_path, "w", encoding="utf-8") as f:
+        json.dump({"corpus": {"path": "./corpus/"}, "data": training_data}, f, indent=2, sort_keys=False)
+
     print(f"  Wrote {train_json_path}")
-    
+
     # Create corpus parquet and metadata (only once, typically for training set)
     if write_corpus:
-        corpus_list = [{'id': doc_id, 'text': text} for text, doc_id in corpus.items()]
+        corpus_list = [{"id": doc_id, "text": text} for text, doc_id in corpus.items()]
         corpus_df = pd.DataFrame(corpus_list)
-        parquet_path = os.path.join(corpus_dir, 'train.parquet')
+        parquet_path = os.path.join(corpus_dir, "train.parquet")
         corpus_df.to_parquet(parquet_path, index=False)
         print(f"  Wrote {parquet_path} with {len(corpus_list)} documents")
-        
+
         # Create metadata
-        metadata_path = os.path.join(corpus_dir, 'merlin_metadata.json')
-        with open(metadata_path, 'w', encoding='utf-8') as f:
-            json.dump({
-                'corpus_id': corpus_id,
-                'class': 'TextQADataset'
-            }, f, indent=2, sort_keys=False)
-        
+        metadata_path = os.path.join(corpus_dir, "merlin_metadata.json")
+        with open(metadata_path, "w", encoding="utf-8") as f:
+            json.dump({"corpus_id": corpus_id, "class": "TextQADataset"}, f, indent=2, sort_keys=False)
+
         print(f"  Wrote {metadata_path}")
 
 
 def generate_eval_set(
-    corpus: Dict[str, str],
-    chunk_mapping: Dict[Tuple[str, int], str],
+    corpus: dict[str, str],
+    chunk_mapping: dict[tuple[str, int], str],
     eval_df: pd.DataFrame,
     output_dir: str,
     max_pos_docs: int = 5,
     eval_only: bool = False,
-    use_group_id_in_eval: bool = False
+    use_group_id_in_eval: bool = False,
 ) -> None:
     """
     Generate evaluation set in BEIR format.
-    
+
     Args:
         corpus: Dict mapping text -> corpus_id
         chunk_mapping: Dict mapping (file_identifier, chunk_id) -> text
@@ -610,68 +601,63 @@ def generate_eval_set(
         use_group_id_in_eval: If True, use group_id (hash-based) in qrels; otherwise use _id (default)
     """
     print("Generating evaluation set...")
-    
+
     # In eval-only mode, output directly to output_dir; otherwise use eval_beir/ subfolder
     if eval_only:
         eval_dir = output_dir
     else:
-        eval_dir = os.path.join(output_dir, 'eval_beir')
+        eval_dir = os.path.join(output_dir, "eval_beir")
     os.makedirs(eval_dir, exist_ok=True)
-    
+
     # Generate corpus.jsonl
-    corpus_path = os.path.join(eval_dir, 'corpus.jsonl')
+    corpus_path = os.path.join(eval_dir, "corpus.jsonl")
     corpus_id_counter = 0
     text_to_beir_id = {}
-    
-    with open(corpus_path, 'w', encoding='utf-8') as corpus_file:
+
+    with open(corpus_path, "w", encoding="utf-8") as corpus_file:
         for text, hash_id in corpus.items():
-            beir_id = f'd{corpus_id_counter}'
+            beir_id = f"d{corpus_id_counter}"
             text_to_beir_id[text] = beir_id
-            
-            corpus_entry = {
-                '_id': beir_id,
-                'metadata': {},
-                'text': text,
-                'title': ''
-            }
-            
+
+            corpus_entry = {"_id": beir_id, "metadata": {}, "text": text, "title": ""}
+
             # Only include group_id if using it in qrels
             if use_group_id_in_eval:
-                corpus_entry['group_id'] = hash_id
-            
-            corpus_file.write(json.dumps(corpus_entry) + '\n')
+                corpus_entry["group_id"] = hash_id
+
+            corpus_file.write(json.dumps(corpus_entry) + "\n")
             corpus_id_counter += 1
-    
+
     print(f"  Wrote {corpus_path} with {corpus_id_counter} documents")
-    
+
     # Generate queries.jsonl and qrels
-    queries_path = os.path.join(eval_dir, 'queries.jsonl')
+    queries_path = os.path.join(eval_dir, "queries.jsonl")
     query_mappings = []
     query_counter = 0
     skipped_queries = 0
     skipped_too_many_pos = 0
-    
-    with open(queries_path, 'w', encoding='utf-8') as queries_file:
+
+    with open(queries_path, "w", encoding="utf-8") as queries_file:
         for _, qa_pair in eval_df.iterrows():
-            file_name_list = qa_pair.get('file_name', [])
+            file_name_list = qa_pair.get("file_name", [])
             # file_name is now always a list; get canonical identifier
-            file_identifier = get_file_identifier(file_name_list) if file_name_list else ''
-            segment_ids = qa_pair.get('segment_ids', [])
-            question = qa_pair.get('question', '')
-            
+            file_identifier = get_file_identifier(file_name_list) if file_name_list else ""
+            segment_ids = qa_pair.get("segment_ids", [])
+            question = qa_pair.get("question", "")
+
             if not question:
                 skipped_queries += 1
                 continue
-            
+
             # Handle numpy arrays
-            if hasattr(segment_ids, 'tolist'):
+            if hasattr(segment_ids, "tolist"):
                 segment_ids = segment_ids.tolist()
-            
+
             # Skip queries with too many positive docs
             if len(segment_ids) > max_pos_docs:
                 skipped_too_many_pos += 1
                 continue
-            
+
             # Check if all segments exist
             all_segments_exist = True
             for segment_id in segment_ids:
@@ -679,160 +665,142 @@ def generate_eval_set(
                 if key not in chunk_mapping:
                     all_segments_exist = False
                     break
-            
+
             if not all_segments_exist:
                 skipped_queries += 1
                 continue
-            
-            query_id = f'q{query_counter}'
+
+            query_id = f"q{query_counter}"
             query_mappings.append((query_id, file_identifier, segment_ids))
-            
+
             # Build metadata
             metadata = {}
             metadata_fields = [
-                'query_type', 'reasoning_type', 'hop_count',
-                'question_complexity', 'quality_score', 'answer',
-                'hop_contexts'
+                "query_type",
+                "reasoning_type",
+                "hop_count",
+                "question_complexity",
+                "quality_score",
+                "answer",
+                "hop_contexts",
             ]
-            
+
             for field in metadata_fields:
                 val = qa_pair.get(field)
                 if val is not None:
-                    if hasattr(val, 'tolist'):
+                    if hasattr(val, "tolist"):
                         val = val.tolist()
                     metadata[field] = val
-            
-            metadata['file_name'] = file_name_list
-            metadata['segment_ids'] = segment_ids
-            
-            query_entry = {
-                '_id': query_id,
-                'metadata': metadata,
-                'text': question
-            }
-            
-            queries_file.write(json.dumps(query_entry) + '\n')
+
+            metadata["file_name"] = file_name_list
+            metadata["segment_ids"] = segment_ids
+
+            query_entry = {"_id": query_id, "metadata": metadata, "text": question}
+
+            queries_file.write(json.dumps(query_entry) + "\n")
             query_counter += 1
-    
+
     print(f"  Wrote {queries_path} with {query_counter} queries")
     if skipped_queries > 0:
         print(f"  Skipped {skipped_queries} queries (missing segments or empty question)")
     if skipped_too_many_pos > 0:
         print(f"  Skipped {skipped_too_many_pos} queries (exceeded max_pos_docs={max_pos_docs})")
-    
+
     # Generate qrels/test.tsv
-    qrels_dir = os.path.join(eval_dir, 'qrels')
+    qrels_dir = os.path.join(eval_dir, "qrels")
     os.makedirs(qrels_dir, exist_ok=True)
-    
-    qrels_path = os.path.join(qrels_dir, 'test.tsv')
+
+    qrels_path = os.path.join(qrels_dir, "test.tsv")
     qrels_count = 0
-    
-    with open(qrels_path, 'w', encoding='utf-8') as qrels_file:
-        qrels_file.write('query-id\tcorpus-id\tscore\n')
-        
+
+    with open(qrels_path, "w", encoding="utf-8") as qrels_file:
+        qrels_file.write("query-id\tcorpus-id\tscore\n")
+
         for query_id, file_identifier, segment_ids in query_mappings:
             for segment_id in segment_ids:
                 key = (file_identifier, segment_id)
                 text = chunk_mapping[key]
-                
+
                 # Use group_id (hash-based) or _id (beir sequential id) based on flag
                 if use_group_id_in_eval:
                     doc_id = corpus[text]  # hash-based group_id
                 else:
                     doc_id = text_to_beir_id[text]  # sequential _id (e.g., d0, d1, ...)
-                
+
                 qrels_file.write(f"{query_id}\t{doc_id}\t1\n")
                 qrels_count += 1
-    
+
     id_type = "group_id" if use_group_id_in_eval else "_id"
     print(f"  Wrote {qrels_path} with {qrels_count} mappings (using {id_type})")
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Convert SDG output to retriever data formats (training and/or evaluation)'
+        description="Convert SDG output to retriever data formats (training and/or evaluation)"
     )
     parser.add_argument(
-        'input_path',
-        type=str,
-        help='Path to merged JSON file or folder containing generated_batch*.json files'
+        "input_path", type=str, help="Path to merged JSON file or folder containing generated_batch*.json files"
     )
+    parser.add_argument("--corpus-id", type=str, required=True, help='Corpus identifier (e.g., "my_corpus")')
     parser.add_argument(
-        '--corpus-id',
-        type=str,
-        required=True,
-        help='Corpus identifier (e.g., "my_corpus")'
-    )
-    parser.add_argument(
-        '--output-dir',
+        "--output-dir",
         type=str,
         default=None,
-        help='Path to output directory (default: <input>_train_eval or <input>_eval with --eval-only)'
+        help="Path to output directory (default: <input>_train_eval or <input>_eval with --eval-only)",
     )
     parser.add_argument(
-        '--eval-only',
-        action='store_true',
-        help='Generate only evaluation data in BEIR format (no train/val splits, no corpus parquet)'
+        "--eval-only",
+        action="store_true",
+        help="Generate only evaluation data in BEIR format (no train/val splits, no corpus parquet)",
     )
     parser.add_argument(
-        '--train-ratio',
+        "--train-ratio",
         type=float,
         default=0.8,
-        help='Ratio of files for training (default: 0.8, ignored with --eval-only)'
+        help="Ratio of files for training (default: 0.8, ignored with --eval-only)",
     )
     parser.add_argument(
-        '--val-ratio',
+        "--val-ratio",
         type=float,
         default=0.1,
-        help='Ratio of files for validation (default: 0.1, ignored with --eval-only)'
+        help="Ratio of files for validation (default: 0.1, ignored with --eval-only)",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility (default: 42)")
+    parser.add_argument(
+        "--quality-threshold", type=float, default=7.0, help="Minimum quality score for QA pairs (default: 7.0)"
     )
     parser.add_argument(
-        '--seed',
-        type=int,
-        default=42,
-        help='Random seed for reproducibility (default: 42)'
-    )
-    parser.add_argument(
-        '--quality-threshold',
-        type=float,
-        default=7.0,
-        help='Minimum quality score for QA pairs (default: 7.0)'
-    )
-    parser.add_argument(
-        '--max-pos-docs',
+        "--max-pos-docs",
         type=int,
         default=5,
-        help='Maximum number of positive docs (segment_ids) per query (default: 5)'
+        help="Maximum number of positive docs (segment_ids) per query (default: 5)",
     )
     parser.add_argument(
-        '--use-group-id-in-eval',
-        action='store_true',
-        help='Use group_id (hash-based) instead of _id in qrels (default: use _id)'
+        "--use-group-id-in-eval",
+        action="store_true",
+        help="Use group_id (hash-based) instead of _id in qrels (default: use _id)",
     )
-    
+
     args = parser.parse_args()
-    
+
     # Validate input path
     input_path = os.path.abspath(args.input_path)
     if not os.path.exists(input_path):
         raise ValueError(f"Input path does not exist: {input_path}")
-    
+
     # Set default output directory based on input path and mode
     if args.output_dir is None:
-        suffix = '_eval' if args.eval_only else '_train_eval'
+        suffix = "_eval" if args.eval_only else "_train_eval"
         if os.path.isfile(input_path):
             # For single file, use filename without extension
             input_basename = os.path.splitext(os.path.basename(input_path))[0]
-            output_dir = os.path.join(
-                os.path.dirname(input_path),
-                f"{input_basename}{suffix}"
-            )
+            output_dir = os.path.join(os.path.dirname(input_path), f"{input_basename}{suffix}")
         else:
-            output_dir = os.path.abspath(input_path.rstrip('/') + suffix)
+            output_dir = os.path.abspath(input_path.rstrip("/") + suffix)
     else:
         output_dir = os.path.abspath(args.output_dir)
     os.makedirs(output_dir, exist_ok=True)
-    
+
     print("=" * 80)
     print("SDG to Retriever Data Converter")
     print("=" * 80)
@@ -850,36 +818,44 @@ def main():
     print(f"Max positive docs: {args.max_pos_docs}")
     print(f"Eval qrels ID type: {'group_id' if args.use_group_id_in_eval else '_id'}")
     print()
-    
+
     # Step 1: Load generated data
     print("=" * 80)
     print("Step 1: Loading generated data")
     print("=" * 80)
     generated_df = load_generated_json_files(input_path)
     print()
-    
+
     # Step 2: Build corpus and mappings
     print("=" * 80)
     print("Step 2: Building corpus and mappings")
     print("=" * 80)
     corpus, chunk_mapping = build_corpus_and_mappings(generated_df)
     print()
-    
+
     # Step 3: Filter QA pairs by quality
     print("=" * 80)
     print("Step 3: Filtering QA pairs by quality")
     print("=" * 80)
     filtered_qa_df, skipped_files = filter_qa_pairs_by_quality(generated_df, args.quality_threshold)
     print()
-    
+
     if args.eval_only:
         # Eval-only mode: generate BEIR format directly
         print("=" * 80)
         print("Step 4: Generating evaluation set (BEIR format)")
         print("=" * 80)
-        generate_eval_set(corpus, chunk_mapping, filtered_qa_df, output_dir, args.max_pos_docs, eval_only=True, use_group_id_in_eval=args.use_group_id_in_eval)
+        generate_eval_set(
+            corpus,
+            chunk_mapping,
+            filtered_qa_df,
+            output_dir,
+            args.max_pos_docs,
+            eval_only=True,
+            use_group_id_in_eval=args.use_group_id_in_eval,
+        )
         print()
-        
+
         print("=" * 80)
         print("Conversion complete!")
         print("=" * 80)
@@ -898,34 +874,55 @@ def main():
             filtered_qa_df, args.train_ratio, args.val_ratio, args.seed
         )
         print()
-        
+
         # Step 5: Generate training set
         print("=" * 80)
         print("Step 5: Generating training set")
         print("=" * 80)
         generate_training_set(
-            corpus, chunk_mapping, train_df, output_dir, args.corpus_id, args.max_pos_docs,
-            output_filename='train.json', set_name='training'
+            corpus,
+            chunk_mapping,
+            train_df,
+            output_dir,
+            args.corpus_id,
+            args.max_pos_docs,
+            output_filename="train.json",
+            set_name="training",
         )
         print()
-        
+
         # Step 6: Generate validation set
         print("=" * 80)
         print("Step 6: Generating validation set")
         print("=" * 80)
         generate_training_set(
-            corpus, chunk_mapping, val_df, output_dir, args.corpus_id, args.max_pos_docs,
-            output_filename='val.json', set_name='validation', write_corpus=False
+            corpus,
+            chunk_mapping,
+            val_df,
+            output_dir,
+            args.corpus_id,
+            args.max_pos_docs,
+            output_filename="val.json",
+            set_name="validation",
+            write_corpus=False,
         )
         print()
-        
+
         # Step 7: Generate test/evaluation set
         print("=" * 80)
         print("Step 7: Generating test/evaluation set")
         print("=" * 80)
-        generate_eval_set(corpus, chunk_mapping, test_df, output_dir, args.max_pos_docs, eval_only=False, use_group_id_in_eval=args.use_group_id_in_eval)
+        generate_eval_set(
+            corpus,
+            chunk_mapping,
+            test_df,
+            output_dir,
+            args.max_pos_docs,
+            eval_only=False,
+            use_group_id_in_eval=args.use_group_id_in_eval,
+        )
         print()
-        
+
         print("=" * 80)
         print("Conversion complete!")
         print("=" * 80)
@@ -935,7 +932,7 @@ def main():
         print("  - val.json (retriever validation format)")
         print("  - corpus/ (parquet + metadata)")
         print("  - eval_beir/ (BEIR test/evaluation format)")
-    
+
     # Print skipped files summary
     if skipped_files:
         print()
@@ -946,5 +943,5 @@ def main():
             print(f"  - {item['file_name']}: {item['reason']}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/recipes/embed/test_convert_to_retriever_data.py
+++ b/tests/recipes/embed/test_convert_to_retriever_data.py
@@ -8,7 +8,10 @@ import random
 import pandas as pd
 
 from nemotron.recipes.embed.stage1_data_prep.scripts.convert_to_retriever_data import (
+    build_corpus_and_mappings,
     create_train_val_test_split,
+    generate_eval_set,
+    get_file_identifier,
     load_generated_json_files,
 )
 
@@ -63,3 +66,78 @@ def test_train_val_test_split_orders_files_before_seeded_shuffle():
 
     assert {row[0] for row in train_df["file_name"]} == expected_train
     assert {row[0] for row in test_df["file_name"]} == expected_test
+
+
+def test_single_doc_identifier_preserves_full_normalized_path():
+    dotted_source = (
+        "researchnvidiacom/"
+        "research.nvidia.com_publication_2022-11_document-one"
+    )
+
+    assert get_file_identifier([dotted_source]) == dotted_source
+    assert get_file_identifier(["./" + dotted_source]) == dotted_source
+    assert get_file_identifier(["corporateblog/60007"]) != get_file_identifier(
+        ["techblog/60007"]
+    )
+
+
+def test_eval_qrels_do_not_collide_for_dotted_source_identifiers(tmp_path):
+    first_source = (
+        "researchnvidiacom/"
+        "research.nvidia.com_publication_2015-03_document-one"
+    )
+    second_source = (
+        "researchnvidiacom/"
+        "research.nvidia.com_publication_2016-04_document-two"
+    )
+    generated_df = pd.DataFrame(
+        [
+            {
+                "file_name": [first_source],
+                "chunks": [{"chunk_id": 1, "text": "first source passage"}],
+            },
+            {
+                "file_name": [second_source],
+                "chunks": [{"chunk_id": 1, "text": "second source passage"}],
+            },
+        ]
+    )
+    eval_df = pd.DataFrame(
+        [
+            {
+                "file_name": [first_source],
+                "segment_ids": [1],
+                "question": "Question about the first source",
+            },
+            {
+                "file_name": [second_source],
+                "segment_ids": [1],
+                "question": "Question about the second source",
+            },
+        ]
+    )
+
+    corpus, chunk_mapping = build_corpus_and_mappings(generated_df)
+    generate_eval_set(corpus, chunk_mapping, eval_df, str(tmp_path))
+
+    corpus_by_id = {
+        record["_id"]: record["text"]
+        for record in (
+            json.loads(line)
+            for line in (tmp_path / "eval_beir" / "corpus.jsonl").read_text().splitlines()
+        )
+    }
+    qrels = {
+        query_id: corpus_by_id[corpus_id]
+        for query_id, corpus_id, _ in (
+            line.split("\t")
+            for line in (tmp_path / "eval_beir" / "qrels" / "test.tsv")
+            .read_text()
+            .splitlines()[1:]
+        )
+    }
+
+    assert qrels == {
+        "q0": "first source passage",
+        "q1": "second source passage",
+    }

--- a/tests/recipes/embed/test_convert_to_retriever_data.py
+++ b/tests/recipes/embed/test_convert_to_retriever_data.py
@@ -69,27 +69,16 @@ def test_train_val_test_split_orders_files_before_seeded_shuffle():
 
 
 def test_single_doc_identifier_preserves_full_normalized_path():
-    dotted_source = (
-        "researchnvidiacom/"
-        "research.nvidia.com_publication_2022-11_document-one"
-    )
+    dotted_source = "researchnvidiacom/research.nvidia.com_publication_2022-11_document-one"
 
     assert get_file_identifier([dotted_source]) == dotted_source
     assert get_file_identifier(["./" + dotted_source]) == dotted_source
-    assert get_file_identifier(["corporateblog/60007"]) != get_file_identifier(
-        ["techblog/60007"]
-    )
+    assert get_file_identifier(["corporateblog/60007"]) != get_file_identifier(["techblog/60007"])
 
 
 def test_eval_qrels_do_not_collide_for_dotted_source_identifiers(tmp_path):
-    first_source = (
-        "researchnvidiacom/"
-        "research.nvidia.com_publication_2015-03_document-one"
-    )
-    second_source = (
-        "researchnvidiacom/"
-        "research.nvidia.com_publication_2016-04_document-two"
-    )
+    first_source = "researchnvidiacom/research.nvidia.com_publication_2015-03_document-one"
+    second_source = "researchnvidiacom/research.nvidia.com_publication_2016-04_document-two"
     generated_df = pd.DataFrame(
         [
             {
@@ -122,18 +111,12 @@ def test_eval_qrels_do_not_collide_for_dotted_source_identifiers(tmp_path):
 
     corpus_by_id = {
         record["_id"]: record["text"]
-        for record in (
-            json.loads(line)
-            for line in (tmp_path / "eval_beir" / "corpus.jsonl").read_text().splitlines()
-        )
+        for record in (json.loads(line) for line in (tmp_path / "eval_beir" / "corpus.jsonl").read_text().splitlines())
     }
     qrels = {
         query_id: corpus_by_id[corpus_id]
         for query_id, corpus_id, _ in (
-            line.split("\t")
-            for line in (tmp_path / "eval_beir" / "qrels" / "test.tsv")
-            .read_text()
-            .splitlines()[1:]
+            line.split("\t") for line in (tmp_path / "eval_beir" / "qrels" / "test.tsv").read_text().splitlines()[1:]
         )
     }
 


### PR DESCRIPTION
## Description

Fixes qrel and training-label corruption caused by lossy single-document source identifiers. Source IDs such as `research.example.com_publication_...` were treated as filenames and truncated by `os.path.splitext()`, allowing unrelated chunk mappings to overwrite each other.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement
- [ ] New training recipe or step

## Changes Made

- Preserve the full normalized source path for single-document chunk-map keys.
- Normalize paths before hashing multi-document bundle keys.
- Add regression coverage proving dotted `research.example.com_...` identifiers generate distinct qrels.
- Apply Ruff lint and formatting cleanup to the converter and its unit test.

## Affected Input Patterns

This issue affects data prepared before this fix when distinct sources produce the same lossy identifier and reuse a chunk ID. The old mapping is last-write-wins, so the later source silently replaces the earlier source's positive passage in training data and evaluation qrels.

| Pattern | Synthetic examples | Pre-fix result |
|---|---|---|
| Dotted source IDs that are not conventional filenames | `papers/research.example.com_publication_alpha`, `papers/research.example.com_publication_beta` | Both become `research.example` |
| The same leaf ID under different namespaces | `source-a/12345`, `source-b/12345` | Both become `12345` |
| Dotted model or artifact versions | `models/world-model-1.0-small`, `models/world-model-1.0-large` | Both become `world-model-1` |
| The same filename stem with different paths or extensions | `manuals/setup.md`, `archive/setup.pdf` | Both become `setup` |
| Equivalent multi-document paths written differently | `['./docs/a.md', 'docs\\b.md']`, `['docs/a.md', 'docs/b.md']` | Different raw-path hashes can cause missing lookups |

Collisions are semantically harmless only when every overlapping chunk ID has identical text. The self-check below distinguishes those mirrors from cases that change positive passages.

## Self-Check for Existing Data

Run this against the exact Stage 0 JSON/JSONL file or directory used by the embedding recipe. Set `--quality-threshold` and `--max-pos-docs` to the values used for the original preparation run.

```bash
python - /path/to/stage0_sdg --quality-threshold 7.0 --max-pos-docs 5 <<'PY'
import argparse
import hashlib
import json
import os
from collections import defaultdict
from pathlib import Path


def load_records(path):
    content = path.read_text(encoding="utf-8")
    try:
        records = json.loads(content)
    except json.JSONDecodeError:
        records = [json.loads(line) for line in content.splitlines() if line.strip()]
    return records if isinstance(records, list) else [records]


def input_files(input_path):
    if input_path.is_file():
        return [input_path]
    files = sorted(input_path.glob("generated_batch*.json"))
    if not files:
        files = sorted([*input_path.glob("*.json"), *input_path.glob("*.jsonl")])
    return files


def file_names(record):
    names = record.get("file_name", [])
    if isinstance(names, str):
        return [names]
    return [str(name) for name in names]


def old_identifier(names):
    if len(names) == 1:
        return os.path.splitext(os.path.basename(names[0]))[0]
    return hashlib.md5("||".join(sorted(names)).encode()).hexdigest()[:16]


def normalize_path(path):
    return os.path.normpath(path.replace("\\", "/")).replace("\\", "/")


def fixed_identifier(names):
    normalized = sorted(normalize_path(name) for name in names)
    if len(normalized) == 1:
        return normalized[0]
    return hashlib.md5("||".join(normalized).encode()).hexdigest()[:16]


parser = argparse.ArgumentParser()
parser.add_argument("input_path", type=Path)
parser.add_argument("--quality-threshold", type=float, default=7.0)
parser.add_argument("--max-pos-docs", type=int, default=5)
args = parser.parse_args()

files = input_files(args.input_path)
if not files:
    raise SystemExit(f"No JSON/JSONL files found under {args.input_path}")

records = []
for path in files:
    records.extend(load_records(path))

prepared = []
old_mapping = {}
texts_by_old_chunk = defaultdict(dict)
sources_by_old_id = defaultdict(set)
old_ids_by_fixed_id = defaultdict(set)

for record in records:
    names = file_names(record)
    if not names:
        continue

    source = tuple(names)
    old_id = old_identifier(names)
    fixed_id = fixed_identifier(names)
    chunks = {
        chunk.get("chunk_id"): chunk.get("text", "")
        for chunk in record.get("chunks", [])
        if isinstance(chunk, dict)
        and chunk.get("chunk_id") is not None
        and chunk.get("text", "")
    }

    prepared.append((record, source, old_id, chunks))
    sources_by_old_id[old_id].add(source)
    old_ids_by_fixed_id[fixed_id].add(old_id)

    for chunk_id, text in chunks.items():
        old_mapping[(old_id, chunk_id)] = (source, text)
        texts_by_old_chunk[(old_id, chunk_id)][source] = text

lossy_identifier_groups = sum(
    len(sources) > 1 for sources in sources_by_old_id.values()
)
conflicting_chunk_keys = sum(
    len(set(text_by_source.values())) > 1
    for text_by_source in texts_by_old_chunk.values()
)
path_normalization_risks = sum(
    len(old_ids) > 1 for old_ids in old_ids_by_fixed_id.values()
)

eligible_qa_pairs = 0
affected_qa_pairs = 0
affected_positive_links = 0

for record, source, old_id, chunks in prepared:
    qa_pairs = record.get("deduplicated_qa_pairs", [])
    evaluations = record.get("qa_evaluations", {}).get("evaluations", [])
    if len(qa_pairs) != len(evaluations):
        continue

    for qa_pair, evaluation in zip(qa_pairs, evaluations):
        score = evaluation.get("overall", {}).get("score", 0)
        segment_ids = qa_pair.get("segment_ids", [])
        if (
            score < args.quality_threshold
            or not qa_pair.get("question")
            or not segment_ids
            or len(segment_ids) > args.max_pos_docs
        ):
            continue

        if not all(
            segment_id in chunks and (old_id, segment_id) in old_mapping
            for segment_id in segment_ids
        ):
            continue

        eligible_qa_pairs += 1
        changed_links = sum(
            old_mapping[(old_id, segment_id)][1] != chunks[segment_id]
            for segment_id in segment_ids
        )
        if changed_links:
            affected_qa_pairs += 1
            affected_positive_links += changed_links

affected_qa_percentage = (
    100.0 * affected_qa_pairs / eligible_qa_pairs if eligible_qa_pairs else 0.0
)

print(f"records_checked={len(records)}")
print(f"lossy_identifier_groups={lossy_identifier_groups}")
print(f"conflicting_chunk_keys={conflicting_chunk_keys}")
print(f"path_normalization_risks={path_normalization_risks}")
print(f"eligible_qa_pairs={eligible_qa_pairs}")
print(f"affected_qa_pairs={affected_qa_pairs}")
print(f"affected_qa_percentage={affected_qa_percentage:.2f}%")
print(f"affected_positive_links={affected_positive_links}")

if affected_qa_pairs:
    print("AFFECTED: rebuild Stage 1 data and rerun dependent fine-tuning/evaluation.")
else:
    if conflicting_chunk_keys or path_normalization_risks:
        print(
            "WARNING: identifier or path risks exist, but they did not change "
            "any eligible QA positive."
        )
    print("NOT AFFECTED by this source-identifier bug under the supplied settings.")
PY
```

The final result is conclusive only when the command uses the exact Stage 0 input, quality threshold, and maximum-positive setting from the original preparation run. Interpret it as follows:

- `AFFECTED`: outputs created before this fix contain changed positive passages. Rebuild Stage 1 data and rerun every embedding fine-tuning or evaluation job that consumed those outputs.
- `NOT AFFECTED`: no rerun is required for this bug when the supplied input and settings match the original run. A preceding warning means risky identifiers exist, but they did not alter any eligible QA positive in that run.

`affected_qa_percentage` is the percentage of output-eligible QA pairs whose positive passages changed (`affected_qa_pairs / eligible_qa_pairs`). It quantifies the severity for the supplied preparation settings; any nonzero value still confirms that the old outputs contain incorrect labels.

If the original Stage 0 input or preparation settings are unavailable, this check cannot determine whether the old outputs were affected. The safe recovery is to rebuild Stage 1 data with this fix and rerun any dependent fine-tuning and evaluation.

To rebuild the prepared data after updating to this fix:

```bash
nemotron embed prep -c default sdg_input_path=/path/to/stage0_sdg
```

If a checkpoint was fine-tuned from affected `train.json` or `val.json` data, regenerating only the evaluation files is insufficient; the fine-tuning run must also be repeated.

## Testing

```bash
UV_CACHE_DIR=/raid/sthan/codex/tmp/uv-cache .venv/bin/python -m pytest tests/recipes/embed -q
# 189 passed, 6 skipped

.venv/bin/python -m ruff check tests/recipes/embed/test_convert_to_retriever_data.py
.venv/bin/python -m ruff check src/nemotron/recipes/embed/stage1_data_prep/scripts/convert_to_retriever_data.py
.venv/bin/python -m ruff format --check src/nemotron/recipes/embed/stage1_data_prep/scripts/convert_to_retriever_data.py tests/recipes/embed/test_convert_to_retriever_data.py
.venv/bin/python -m py_compile src/nemotron/recipes/embed/stage1_data_prep/scripts/convert_to_retriever_data.py
```

The self-check snippet was additionally validated with synthetic fixtures covering affected collisions, text-identical mirrors, and multi-document path-normalization risk.

## Checklist

- [x] My code follows the existing style conventions (ruff + ruff-format)
- [x] I have added type hints and docstrings where applicable
- [x] I have added tests for new functionality
- [x] All existing and new tests pass
- [x] I have updated documentation where needed
- [x] My commits are signed off (`git commit -s`) per the DCO

## Additional Notes
