### PR TITLE
Use Nemotron 3 embed for dedup embeddings

### DIFF
--- a/src/nemotron/recipes/embed/stage0_sdg/config/default.yaml
+++ b/src/nemotron/recipes/embed/stage0_sdg/config/default.yaml
@@ -133,7 +133,7 @@ quality_judge_model: nvidia/nemotron-3-ultra-550b-a55b
 quality_judge_provider: nvidia
 
 # Embedding
-embed_model: nvidia/llama-nemotron-embed-1b-v2
+embed_model: nvidia/nemotron-3-embed-1b
 embed_provider: nvidia
 
 # Maximum parallel requests for generation models (null = library default)

--- a/src/nemotron/recipes/embed/stage0_sdg/config/llama.yaml
+++ b/src/nemotron/recipes/embed/stage0_sdg/config/llama.yaml
@@ -133,7 +133,7 @@ quality_judge_model: nvidia/nemotron-3-nano-30b-a3b
 quality_judge_provider: nvidia
 
 # Embedding
-embed_model: nvidia/llama-nemotron-embed-1b-v2
+embed_model: nvidia/nemotron-3-embed-1b
 embed_provider: nvidia
 
 # Maximum parallel requests for generation models (null = library default)

--- a/src/nemotron/recipes/embed/stage0_sdg/data_prep.py
+++ b/src/nemotron/recipes/embed/stage0_sdg/data_prep.py
@@ -164,7 +164,7 @@ class SDGConfig(RecipeSettings):
         default="nvidia/nemotron-3-ultra-550b-a55b", description="Model name for quality judge."
     )
     quality_judge_provider: str = Field(default="nvidia", description="Provider for quality judge model.")
-    embed_model: str = Field(default="nvidia/llama-nemotron-embed-1b-v2", description="Model name for embeddings.")
+    embed_model: str = Field(default="nvidia/nemotron-3-embed-1b", description="Model name for embeddings.")
     embed_provider: str = Field(default="nvidia", description="Provider for embedding model.")
     max_parallel_requests_for_gen: int | None = Field(
         default=None,

--- a/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/pipeline.py
+++ b/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/pipeline.py
@@ -70,7 +70,7 @@ def custom_model_config(
     qa_generation_provider: str = "nvidia",
     quality_judge_model: str = "nvidia/llama-3.3-nemotron-super-49b-v1.5",
     quality_judge_provider: str = "nvidia",
-    embed_model: str = "nvidia/llama-nemotron-embed-1b-v2",
+    embed_model: str = "nvidia/nemotron-3-embed-1b",
     embed_provider: str = "nvidia",
     max_parallel_requests_for_gen: Optional[int] = None,
 ) -> Tuple[List[dd.ModelConfig], Dict[str, str]]:
@@ -950,7 +950,7 @@ def build_qa_generation_pipeline(
         qa_generation_provider: str = "nvidia",
         quality_judge_model: str = "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         quality_judge_provider: str = "nvidia",
-        embed_model: str = "nvidia/llama-nemotron-embed-1b-v2",
+        embed_model: str = "nvidia/nemotron-3-embed-1b",
         embed_provider: str = "nvidia",
     ) -> dd.DataDesignerConfigBuilder:
     """Create a simple query generation config for text files.
@@ -1729,7 +1729,7 @@ def generate(
     qa_generation_provider: str = "nvidia",
     quality_judge_model: str = "nvidia/llama-3.3-nemotron-super-49b-v1.5",
     quality_judge_provider: str = "nvidia",
-    embed_model: str = "nvidia/llama-nemotron-embed-1b-v2",
+    embed_model: str = "nvidia/nemotron-3-embed-1b",
     embed_provider: str = "nvidia",
     nvidia_api_base_url: Optional[str] = None,
 ) -> None:
@@ -1771,7 +1771,7 @@ def generate(
         qa_generation_provider: Provider for QA generation model (default: nvidia)
         quality_judge_model: Model name for quality judge (default: nvidia/llama-3.3-nemotron-super-49b-v1.5)
         quality_judge_provider: Provider for quality judge model (default: nvidia)
-        embed_model: Model name for embeddings (default: nvidia/llama-nemotron-embed-1b-v2)
+        embed_model: Model name for embeddings (default: nvidia/nemotron-3-embed-1b)
         embed_provider: Provider for embedding model (default: nvidia)
     Examples:
         # Generate from text files (processes all in batches of 200)

--- a/tests/recipes/embed/test_profiles.py
+++ b/tests/recipes/embed/test_profiles.py
@@ -132,7 +132,7 @@ def test_default_sdg_uses_configured_api() -> None:
     assert sdg.artifact_extraction_model == "nvidia/nemotron-3-ultra-550b-a55b"
     assert sdg.qa_generation_model == sdg.artifact_extraction_model
     assert sdg.quality_judge_model == sdg.artifact_extraction_model
-    assert sdg.embed_model == "nvidia/llama-nemotron-embed-1b-v2"
+    assert sdg.embed_model == "nvidia/nemotron-3-embed-1b"
 
 
 def test_default_nim_identity_is_shared_by_eval_and_deploy() -> None:


### PR DESCRIPTION
## Summary

Update the embed recipe's Stage 0 SDG dedup embedding default to `nvidia/nemotron-3-embed-1b` now that the hosted endpoint is available.

This changes the default and llama Stage 0 configs, the Python settings/defaults used by the vendored retriever SDG entry points, and the profile assertion.

## Validation

- `env UV_CACHE_DIR=/tmp/nemotron-n3-dedup-main-uv-cache PYTHONUNBUFFERED=1 .venv/bin/python -m nemotron embed sdg -c default artifact_root=/tmp/nemotron-n3-dedup-main-smoke corpus_dir=hf://nvidia/Retrieval-Synthetic-NVDocs-v1@1c0d1856f3fb595b2dda98d4b61061fa6d782d51/sample_corpus/nv_pp_random num_files=2 num_pairs=1 batch_size=2 max_parallel_requests_for_gen=1 artifact_extraction_model=nvidia/nemotron-3-nano-30b-a3b qa_generation_model=nvidia/nemotron-3-nano-30b-a3b quality_judge_model=nvidia/nemotron-3-nano-30b-a3b embed_model=nvidia/nemotron-3-embed-1b`
  - `nvidia/nemotron-3-embed-1b` usage: `requests: success=2, failed=0, total=2`
- Post-patch default-config smoke without an `embed_model` override completed successfully with compiled config `embed_model: nvidia/nemotron-3-embed-1b`
  - `nvidia/nemotron-3-embed-1b` usage: `requests: success=2, failed=0, total=2`
- `.venv/bin/pytest tests/recipes/embed/test_profiles.py tests/recipes/embed/test_sdg.py -q` (`45 passed`)
- `git diff --check`
