### PR TITLE
fix(steps): point translate/nemo_curator docs reference at existing page

### DIFF
--- a/src/nemotron/steps/translate/nemo_curator/step.toml
+++ b/src/nemotron/steps/translate/nemo_curator/step.toml
@@ -156,7 +156,7 @@ recovery = "Curator readers are file-partition oriented. For one huge file, gene
 [reference]
 skill = "src/nemotron/steps/translate/nemo_curator/README.md"
 script = "src/nemotron/steps/translate/nemo_curator/step.py"
-docs = "docs/customize/steps/translate/nemo-curator.md"
+docs = "docs/translation/getting-started.md"
 skills = [
   "skills/nemotron-customize/references/context/curator-translation-faith.txt",
 ]


### PR DESCRIPTION
## Problem

`src/nemotron/steps/translate/nemo_curator/step.toml` declares:

```toml
[reference]
docs = "docs/customize/steps/translate/nemo-curator.md"
```

`docs/customize/` does not exist in the repo, so the manifest validation test fails on `main`:

```
FAILED tests/steps/test_manifests.py::test_reference_paths_point_to_real_files
AssertionError: .../step.toml: missing reference path 'docs/customize/steps/translate/nemo-curator.md'
```

This is the only `docs/customize` reference in any `step.toml`.

## Fix

Point `docs` at `docs/translation/getting-started.md` — the existing tutorial that walks through running this exact step (`nemotron steps run translate/nemo_curator`).

## Testing

- `pytest tests/steps/test_manifests.py` — 6 passed (previously 1 failed)