### PR TITLE
fix(kit): resolve version aliases to ints in Artifact.from_uri

### DIFF
--- a/src/nemotron/kit/artifacts/base.py
+++ b/src/nemotron/kit/artifacts/base.py
@@ -415,13 +415,16 @@ class Artifact(BaseModel):
 
         # Set registry metadata
         artifact._name = name
-        if version is not None:
+        if isinstance(version, int):
             artifact._version = version
         else:
-            # Get latest version number
+            # Resolve alias string (or latest) to a concrete version number
             entry = registry.get(name)
-            if entry and entry.versions:
-                artifact._version = entry.versions[-1].version
+            if entry:
+                if version is not None and version in entry.aliases:
+                    artifact._version = entry.aliases[version]
+                elif entry.versions:
+                    artifact._version = entry.versions[-1].version
 
         return artifact
 


### PR DESCRIPTION
## Problem

`Artifact.from_uri("art://name:prod")` (alias version) stored the alias **string** in `artifact._version`, which is typed `int | None`. The `uri`/`art_path` properties then emit a corrupted URI:

```python
art = Artifact.from_uri("art://a:prod")
art._version   # 'prod'  (str, should be int)
art.uri        # 'art://a:vprod'  -> unresolvable on round-trip
```

## Fix

In `from_uri`, only assign `_version` directly when the parsed version is an `int`; resolve alias strings through the registry entry's alias table, falling back to the latest version.

All URI forms now round-trip correctly:

```
art://a:prod   -> _version=1  uri=art://a:v1
art://a:v1     -> _version=1  uri=art://a:v1
art://a:1      -> _version=1  uri=art://a:v1
art://a:latest -> _version=1  uri=art://a:v1
art://a        -> _version=1  uri=art://a:v1
```

## Testing

- Reproduced the bug and verified the fix with a local fsspec registry (alias `prod` -> v1)
- `pytest tests/kit` — 90 passed