### PR TITLE
fix(runspec): reject unsupported executors in nemo-run pipeline launcher

### DIFF
--- a/src/nemo_runspec/pipeline.py
+++ b/src/nemo_runspec/pipeline.py
@@ -298,7 +298,7 @@ def run_nemo_run(
             launcher="torchrun",
             env_vars=env_vars,
         )
-    else:  # slurm
+    elif config.executor == "slurm":
         # Validate required args
         if not config.account:
             _log_error("--account required for Slurm executor")
@@ -335,6 +335,12 @@ def run_nemo_run(
             tunnel=tunnel,
             env_vars=env_vars,
         )
+    else:
+        _log_error(
+            f"Executor {config.executor!r} is not supported by the nemo-run pipeline launcher "
+            "(supported: 'local', 'slurm')"
+        )
+        return 1
 
     # Build and run experiment
     with run.Experiment(config.job_name) as exp:


### PR DESCRIPTION
## Problem

`PipelineConfig.executor` is declared as `Literal["local", "slurm", "dgxcloud", "lepton"]`, but `run_nemo_run` only special-cases `"local"`:

```python
if config.executor == "local":
    executor = run.LocalExecutor(...)
else:  # slurm
    ...
    executor = run.SlurmExecutor(...)
```

Every other value — including `"dgxcloud"` and `"lepton"` — falls into the `else` branch, so a user passing `executor="dgxcloud"` gets either a misleading `--account required for Slurm executor` error or, worse, a Slurm job silently submitted to the wrong backend.

## Fix

Make the Slurm branch explicit (`elif config.executor == "slurm"`) and reject anything else with a clear error:

```
[pipeline] ERROR: Executor 'dgxcloud' is not supported by the nemo-run pipeline launcher (supported: 'local', 'slurm')
```

## Testing

- Verified `dgxcloud`/`lepton` now return rc=1 with the clear error; `slurm` without `--account` still hits its proper validation
- `pytest tests/nemo_runspec` — 186 passed, 3 pre-existing failures on `main` (unrelated data_mover/lepton tests, fail identically without this change)