### PR TITLE
fix(runspec): support art://name/file URIs without version specifier

### DIFF
--- a/src/nemo_runspec/filesystem.py
+++ b/src/nemo_runspec/filesystem.py
@@ -112,12 +112,27 @@ class ArtifactFileSystem(AbstractFileSystem):
                 break
         else:
             # No version specifier found - entire path could be artifact name or name/file
-            # Heuristic: if there's no version, assume no file path (user wants artifact root)
-            artifact_ref = path
-            file_path = ""
+            # art://name/path/to/file implies latest, so split off the first segment as
+            # the artifact name when it exists in the local registry; otherwise keep the
+            # whole path as the artifact reference (e.g. W&B entity/project/name).
+            first, sep, rest = path.partition("/")
+            if sep and rest and self._is_local_artifact(first):
+                artifact_ref = first
+                file_path = rest
+            else:
+                artifact_ref = path
+                file_path = ""
             version = None
 
         return artifact_ref, version, file_path
+
+    @staticmethod
+    def _is_local_artifact(name: str) -> bool:
+        """Check whether name exists in the local artifact registry."""
+        try:
+            return get_artifact_registry().get(name) is not None
+        except Exception:
+            return False
 
     def _resolve(self, path: str) -> tuple[Path, str]:
         """Resolve art:// path to local filesystem path.


### PR DESCRIPTION
## Problem

`ArtifactFileSystem` documents this URI form:

```
art://name/path/to/file  (implies latest)
```

But when no `:version` specifier is present, `_parse_uri` treats the **entire** path (including the file part) as the artifact name:

```python
fs._parse_uri("art://my-dataset/train.json")
# -> ('my-dataset/train.json', None, '')   # name swallows the file path
```

Since the resulting name contains `/`, `_resolve()` routes it to the W&B full-path resolver, so opening a file from a **local** registry artifact fails (e.g. `UsageError: No API key configured`).

## Fix

In the no-version branch, split the first segment off as the artifact name when it exists in the local registry; otherwise keep the whole path as the artifact reference (preserving W&B `entity/project/name` paths without a version).

```python
fs._parse_uri("art://my-dataset/train.json")   # ('my-dataset', None, 'train.json')
fs._parse_uri("art://my-dataset:v1/train.json") # ('my-dataset', 1, 'train.json')   (unchanged)
fs._parse_uri("art://my-dataset")               # ('my-dataset', None, '')          (unchanged)
fs._parse_uri("art://entity/project/name")      # ('entity/project/name', None, '') (unchanged)
```

## Testing

- Verified all forms above plus end-to-end `fs._open("art://my-dataset/train.json")` against a local fsspec registry
- `pytest tests/nemo_runspec -k "filesystem or artifact or registry"` — 34 passed
- Full `tests/nemo_runspec` — 186 passed, 3 pre-existing failures on `main` (unrelated data_mover/lepton tests)