### PR TITLE
fix: Untested summary job masks gh query failures

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -43,15 +43,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Result
-        run: |
-          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
-
-          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
-              echo "✅ All previous jobs completed successfully"
-              exit 0
-          else
-              echo "❌ Found $FAILED_JOBS failed job(s)"
-              # Show which jobs failed
-              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
-              exit 1
-          fi
+        run: ./.github/scripts/summarize_failed_jobs.sh
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          SKIPPING_IS_ALLOWED: ${{ vars.SKIPPING_IS_ALLOWED }}


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/build_docs.yml`: Untested summary job masks gh query failures.

## Changes
- `.github/workflows/build_docs.yml`: Untested summary job masks gh query failures.

## Details
See the Files changed tab for the exact diff.

## Tests
- `tests/test_summarize_failed_jobs.py`

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).