### PR TITLE
fix(runspec): match repo_root on a path boundary in rewrite_paths_for_remote

### DIFF
--- a/src/nemo_runspec/utils.py
+++ b/src/nemo_runspec/utils.py
@@ -89,8 +89,12 @@ def rewrite_paths_for_remote(obj: Any, repo_root: Path | str) -> Any:
             return f"/nemo_run{suffix}"
 
         # Rewrite absolute paths under repo_root to /nemo_run/code/...
-        if obj.startswith(repo_root_str):
-            rel_path = obj[len(repo_root_str) :].lstrip("/")
+        # Match on a path boundary so a sibling path that merely shares the
+        # repo_root prefix (e.g. "<repo_root>-backup/...") is not mistaken for
+        # a path inside the repo.
+        repo_root_norm = repo_root_str.rstrip("/")
+        if obj == repo_root_norm or obj.startswith(repo_root_norm + "/"):
+            rel_path = obj[len(repo_root_norm) :].lstrip("/")
             return f"/nemo_run/code/{rel_path}"
 
     return obj

--- a/tests/kit/cli/test_utils.py
+++ b/tests/kit/cli/test_utils.py
@@ -126,6 +126,25 @@ class TestRewritePathsForRemote:
         result = rewrite_paths_for_remote("/other/path/file.txt", "/local/repo")
         assert result == "/other/path/file.txt"
 
+    def test_preserve_sibling_path_sharing_prefix(self):
+        """A sibling path that only shares the repo_root prefix is preserved.
+
+        ``/local/repo-backup`` is not inside ``/local/repo`` and must not be
+        rewritten just because it starts with the same characters.
+        """
+        result = rewrite_paths_for_remote("/local/repo-backup/config.yaml", "/local/repo")
+        assert result == "/local/repo-backup/config.yaml"
+
+    def test_rewrite_repo_root_exact_match(self):
+        """The repo root itself maps to the remote code root."""
+        result = rewrite_paths_for_remote("/local/repo", "/local/repo")
+        assert result == "/nemo_run/code/"
+
+    def test_rewrite_ignores_trailing_slash_on_repo_root(self):
+        """A trailing slash on repo_root does not change matching behavior."""
+        result = rewrite_paths_for_remote("/local/repo/src/config.yaml", "/local/repo/")
+        assert result == "/nemo_run/code/src/config.yaml"
+
     def test_rewrite_in_dict(self):
         """Test rewriting paths in a dict."""
         obj = {


### PR DESCRIPTION
## Problem

`rewrite_paths_for_remote()` in `src/nemo_runspec/utils.py` decides whether an absolute path lives inside the repo using a **raw string prefix check**:

```python
if obj.startswith(repo_root_str):
    rel_path = obj[len(repo_root_str):].lstrip("/")
    return f"/nemo_run/code/{rel_path}"
```

`str.startswith` has no notion of a path boundary, so a **sibling path that merely shares the prefix** is misclassified as being inside the repo and rewritten into a corrupt remote path.

Example — repo root `/local/repo`:

| Input | Before (buggy) | After (fixed) |
| --- | --- | --- |
| `/local/repo-backup/config.yaml` | `/nemo_run/code/-backup/config.yaml` ❌ | `/local/repo-backup/config.yaml` ✅ |
| `/local/repo/src/config.yaml` | `/nemo_run/code/src/config.yaml` | `/nemo_run/code/src/config.yaml` (unchanged) |

This function rewrites config values for remote execution (used from `display.py`, `evaluator.py`, and `config/loader.py`), so a mis-rewritten path can silently point a remote job at the wrong location.

## Fix

Match on a path boundary: rewrite only when the path **equals** `repo_root` or **begins with `repo_root + "/"`**. A trailing slash on `repo_root` is also normalized so matching is stable regardless of how the caller passes it.

## Tests

Added three regression tests to `tests/kit/cli/test_utils.py`:

- `test_preserve_sibling_path_sharing_prefix` — the actual bug; **fails on `main`**, passes with the fix.
- `test_rewrite_repo_root_exact_match`
- `test_rewrite_ignores_trailing_slash_on_repo_root`

`tests/kit/cli/test_utils.py` — **44 passed**. `ruff check` on both changed files passes.