### PR TITLE
# [Nemotron Embed Fine-Tuning] Log Stage 0 LLM responses and validate empty QA output

### DIFF
--- a/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/pipeline.py
+++ b/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/pipeline.py
@@ -1078,6 +1078,9 @@ INSTRUCTIONS:
 """,
             output_format=DocumentArtifacts,
             model_alias=role_aliases["artifact_extraction"],
+            # Capture the raw assistant message (pre-parse) so a parse failure or
+            # empty/underfilled result can still be root-caused. See issue #314.
+            with_trace=dd.TraceType.LAST_MESSAGE,
         ))
 
     # Define data models for hard question-answer generation
@@ -1294,6 +1297,9 @@ CRITICAL: "query_type" and "reasoning_type" are TWO SEPARATE FIELDS with differe
            num_pairs=num_pairs),
             output_format=QuestionAnswerPairs,
             model_alias=role_aliases["qa_generation"],
+            # Capture the raw assistant message (pre-parse) so a parse failure or
+            # empty/underfilled QA result can still be root-caused. See issue #314.
+            with_trace=dd.TraceType.LAST_MESSAGE,
         ))
 
     config_builder.add_column(
@@ -1683,6 +1689,164 @@ def filter_qa_pairs_by_quality(
     return filtered_df, skipped_files
 
 
+def _extract_pairs(qa_generation: Any) -> List[Any]:
+    """Best-effort extraction of the 'pairs' list from a qa_generation cell."""
+    if qa_generation is None:
+        return []
+    if isinstance(qa_generation, dict):
+        pairs = qa_generation.get("pairs", [])
+    else:
+        pairs = getattr(qa_generation, "pairs", [])
+    if isinstance(pairs, np.ndarray):
+        pairs = pairs.tolist()
+    if not isinstance(pairs, list):
+        return []
+    return pairs
+
+
+def _raw_trace_text(row: "pd.Series", trace_column: str) -> Optional[str]:
+    """Pull the raw assistant message text out of a `{column}__trace` cell, if present."""
+    if trace_column not in row:
+        return None
+    trace = row[trace_column]
+    if isinstance(trace, np.ndarray):
+        trace = trace.tolist()
+    if not trace:
+        return None
+    last_message = trace[-1]
+    if isinstance(last_message, dict):
+        return last_message.get("content")
+    return getattr(last_message, "content", None)
+
+
+def log_stage0_raw_responses(
+    generated_df: "pd.DataFrame",
+    num_pairs: int,
+    batch_idx: int,
+    output_dir: Path,
+    generated_columns: Tuple[str, ...] = ("document_artifacts", "qa_generation"),
+) -> Dict[str, Any]:
+    """Log every raw Stage 0 LLM response before parsing and validate QA output.
+
+    For each generated column, this inspects the parsed value and (when available)
+    the paired `{column}__trace` value captured via `with_trace=TraceType.LAST_MESSAGE`
+    on the corresponding LLMStructuredColumnConfig. It writes one JSONL record per
+    (record index, column, attempt) to `<output_dir>/stage0_raw_responses.jsonl` and
+    returns aggregate counts used for the batch completion summary. See issue #314.
+
+    Args:
+        generated_df: The batch's generated DataFrame, indexed by seed-dataset order.
+        num_pairs: The configured/target number of QA pairs per record.
+        batch_idx: Index of the current batch (used only for log entries).
+        output_dir: Directory the raw-response log file is appended to.
+        generated_columns: Names of the LLM-generated columns to inspect for
+            missing/omitted records.
+
+    Returns:
+        A dict of aggregate counts: requested_records, persisted_records,
+        omitted_by_column, empty_qa_records, underfilled_qa_records,
+        requested_qa_total, generated_qa_total.
+    """
+    log_path = output_dir / "stage0_raw_responses.jsonl"
+    omitted_by_column: Dict[str, int] = {col: 0 for col in generated_columns}
+    omitted_record_indices: set = set()
+    empty_qa_records = 0
+    underfilled_qa_records = 0
+    requested_qa_total = 0
+    generated_qa_total = 0
+    log_lines: List[str] = []
+
+    for record_index, row in generated_df.iterrows():
+        for column in generated_columns:
+            value = row.get(column) if column in row else None
+            is_missing = value is None or (isinstance(value, float) and math.isnan(value))
+
+            if is_missing:
+                omitted_by_column[column] += 1
+                omitted_record_indices.add(record_index)
+
+            # Only log an entry when there's something worth investigating:
+            # the column is missing, or (for qa_generation) the parsed
+            # result is empty/underfilled relative to num_pairs.
+            pairs: Optional[List[Any]] = None
+            is_empty_qa = False
+            is_underfilled_qa = False
+            if column == "qa_generation" and not is_missing:
+                pairs = _extract_pairs(value)
+                requested_qa_total += num_pairs
+                generated_qa_total += len(pairs)
+                if len(pairs) == 0:
+                    is_empty_qa = True
+                    empty_qa_records += 1
+                elif len(pairs) < num_pairs:
+                    is_underfilled_qa = True
+                    underfilled_qa_records += 1
+
+            if not (is_missing or is_empty_qa or is_underfilled_qa):
+                continue
+
+            log_entry = {
+                "batch_index": batch_idx,
+                "record_index": int(record_index),
+                "file_name": row.get("file_name"),
+                "column": column,
+                "attempt": 1,
+                "status": (
+                    "omitted_parse_failure" if is_missing
+                    else "empty_qa" if is_empty_qa
+                    else "underfilled_qa"
+                ),
+                "requested_qa_pairs": num_pairs if column == "qa_generation" else None,
+                "generated_qa_pairs": len(pairs) if pairs is not None else None,
+                "raw_response": _raw_trace_text(row, f"{column}__trace"),
+            }
+            log_lines.append(json.dumps(log_entry, default=str))
+
+    if log_lines:
+        with open(log_path, "a", encoding="utf-8") as log_file:
+            log_file.write("\n".join(log_lines) + "\n")
+
+    return {
+        "requested_records": len(generated_df),
+        "persisted_records": len(generated_df) - len(omitted_record_indices),
+        "omitted_by_column": omitted_by_column,
+        "empty_qa_records": empty_qa_records,
+        "underfilled_qa_records": underfilled_qa_records,
+        "requested_qa_total": requested_qa_total,
+        "generated_qa_total": generated_qa_total,
+    }
+
+
+def print_stage0_batch_summary(batch_label: Any, stats: Dict[str, Any]) -> None:
+    """Print a Stage 0 completion summary for a batch (or the overall run). See issue #314."""
+    print(f"\nStage 0 completion summary (batch {batch_label}):")
+    print(f"  Requested records: {stats['requested_records']}")
+    print(f"  Persisted records: {stats['persisted_records']}")
+    for column, count in stats["omitted_by_column"].items():
+        if count:
+            print(f"  Omitted records ({column}, parse failure): {count}")
+    print(f"  Empty QA results: {stats['empty_qa_records']}")
+    print(f"  Underfilled QA results (< requested count): {stats['underfilled_qa_records']}")
+    print(f"  Requested QA pairs: {stats['requested_qa_total']}")
+    print(f"  Generated QA pairs: {stats['generated_qa_total']}")
+    if stats["requested_qa_total"] > 0:
+        fill_rate = stats["generated_qa_total"] / stats["requested_qa_total"] * 100
+        print(f"  QA fill rate: {fill_rate:.1f}%")
+
+
+def _merge_stage0_stats(total: Dict[str, Any], batch_stats: Dict[str, Any]) -> Dict[str, Any]:
+    """Accumulate a batch's Stage 0 stats into a running total across all batches."""
+    total["requested_records"] += batch_stats["requested_records"]
+    total["persisted_records"] += batch_stats["persisted_records"]
+    for column, count in batch_stats["omitted_by_column"].items():
+        total["omitted_by_column"][column] = total["omitted_by_column"].get(column, 0) + count
+    total["empty_qa_records"] += batch_stats["empty_qa_records"]
+    total["underfilled_qa_records"] += batch_stats["underfilled_qa_records"]
+    total["requested_qa_total"] += batch_stats["requested_qa_total"]
+    total["generated_qa_total"] += batch_stats["generated_qa_total"]
+    return total
+
+
 def _format_duration(seconds: float) -> str:
     """Format a duration in seconds to a human-readable string."""
     seconds = max(0, int(seconds))
@@ -1925,6 +2089,15 @@ def generate(
     input_basename = input_dir.name
     total_batches_to_run = actual_end_batch - start_batch_index
     batch_times: list[float] = []
+    overall_stage0_stats: Dict[str, Any] = {
+        "requested_records": 0,
+        "persisted_records": 0,
+        "omitted_by_column": {},
+        "empty_qa_records": 0,
+        "underfilled_qa_records": 0,
+        "requested_qa_total": 0,
+        "generated_qa_total": 0,
+    }
 
     for batch_idx in range(start_batch_index, actual_end_batch):
         start_idx = batch_idx * batch_size
@@ -1960,6 +2133,16 @@ def generate(
 
         generated_df = result.load_dataset()
 
+        # Log every raw Stage 0 LLM response before parsing, and validate/summarize
+        # empty or underfilled QA output. See issue #314.
+        batch_stage0_stats = log_stage0_raw_responses(
+            generated_df=generated_df,
+            num_pairs=num_pairs,
+            batch_idx=batch_idx,
+            output_dir=output_dir,
+        )
+        overall_stage0_stats = _merge_stage0_stats(overall_stage0_stats, batch_stage0_stats)
+
         # Save batch output to JSON with batch info in filename
         output_filename = f"generated_batch{batch_idx}_{start_idx}_{end_idx}.json"
         generated_df.to_json(output_dir / output_filename, orient='records', indent=2)
@@ -1972,6 +2155,7 @@ def generate(
 
         print(f"Batch {batch_idx}/{num_batches - 1} done in {_format_duration(batch_elapsed)}")
         print(f"  Saved to {output_filename} ({len(generated_df)} records)")
+        print_stage0_batch_summary(batch_idx, batch_stage0_stats)
         if batches_remaining > 0:
             avg_batch_time = sum(batch_times) / len(batch_times)
             eta_seconds = avg_batch_time * batches_remaining
@@ -1983,6 +2167,8 @@ def generate(
     print(f"Total batches processed: {actual_end_batch - start_batch_index}")
     print("\nOutput files:")
     print(f"  - generated_batch{{idx}}_{{start}}_{{end}}.json: Raw generation data per batch")
+    print(f"  - stage0_raw_responses.jsonl: Raw LLM responses for omitted/empty/underfilled records")
+    print_stage0_batch_summary("all", overall_stage0_stats)
 
 
 def entrypoint():

--- a/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/tests/test_stage0_logging.py
+++ b/src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/tests/test_stage0_logging.py
@@ -1,0 +1,213 @@
+"""Tests for Stage 0 raw-response logging and QA output validation.
+
+Covers the behavior requested in issue #314:
+    - Every raw LLM response is logged before parsing (via the `{col}__trace`
+      column produced by `with_trace=TraceType.LAST_MESSAGE`).
+    - Parse failures (missing/None generated columns), empty QA results, and
+      underfilled QA results (fewer pairs than requested) are all detected
+      and logged with their raw response.
+    - The returned/printed summary reports requested vs. persisted records,
+      omitted records by column, and requested vs. generated QA totals.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from retriever_sdg.pipeline import (
+    _extract_pairs,
+    _merge_stage0_stats,
+    _raw_trace_text,
+    log_stage0_raw_responses,
+)
+
+
+def _row(
+    file_name: str,
+    document_artifacts: object = {"key_concepts": []},
+    document_artifacts_trace: object = None,
+    qa_pairs: list | None = None,
+    qa_generation_trace: object = None,
+) -> dict:
+    """Build one synthetic generated_df row."""
+    if qa_pairs is None:
+        qa_pairs = [{"question": "q1"}, {"question": "q2"}]
+    return {
+        "file_name": file_name,
+        "document_artifacts": document_artifacts,
+        "document_artifacts__trace": document_artifacts_trace or [],
+        "qa_generation": {"pairs": qa_pairs} if qa_pairs is not None else None,
+        "qa_generation__trace": qa_generation_trace or [],
+    }
+
+
+class TestExtractPairs:
+    def test_extracts_from_dict(self):
+        assert _extract_pairs({"pairs": [1, 2, 3]}) == [1, 2, 3]
+
+    def test_none_returns_empty_list(self):
+        assert _extract_pairs(None) == []
+
+    def test_missing_pairs_key_returns_empty_list(self):
+        assert _extract_pairs({}) == []
+
+
+class TestRawTraceText:
+    def test_extracts_last_assistant_message_content(self):
+        row = pd.Series({"qa_generation__trace": [{"role": "assistant", "content": "raw text"}]})
+        assert _raw_trace_text(row, "qa_generation__trace") == "raw text"
+
+    def test_missing_trace_column_returns_none(self):
+        row = pd.Series({"qa_generation": {}})
+        assert _raw_trace_text(row, "qa_generation__trace") is None
+
+    def test_empty_trace_returns_none(self):
+        row = pd.Series({"qa_generation__trace": []})
+        assert _raw_trace_text(row, "qa_generation__trace") is None
+
+
+class TestLogStage0RawResponses:
+    def test_healthy_record_is_not_logged(self, tmp_path: Path):
+        df = pd.DataFrame([_row("doc0.txt")])
+        stats = log_stage0_raw_responses(df, num_pairs=2, batch_idx=0, output_dir=tmp_path)
+
+        assert stats["requested_records"] == 1
+        assert stats["persisted_records"] == 1
+        assert stats["empty_qa_records"] == 0
+        assert stats["underfilled_qa_records"] == 0
+        assert not (tmp_path / "stage0_raw_responses.jsonl").exists()
+
+    def test_parse_failure_is_logged_with_raw_response(self, tmp_path: Path):
+        df = pd.DataFrame(
+            [
+                _row(
+                    "doc1.txt",
+                    document_artifacts=None,
+                    document_artifacts_trace=[{"role": "assistant", "content": "not parsable json"}],
+                )
+            ]
+        )
+        stats = log_stage0_raw_responses(df, num_pairs=2, batch_idx=0, output_dir=tmp_path)
+
+        assert stats["omitted_by_column"]["document_artifacts"] == 1
+        assert stats["persisted_records"] == 0
+
+        entries = _read_jsonl(tmp_path / "stage0_raw_responses.jsonl")
+        assert len(entries) == 1
+        assert entries[0]["status"] == "omitted_parse_failure"
+        assert entries[0]["column"] == "document_artifacts"
+        assert entries[0]["raw_response"] == "not parsable json"
+
+    def test_empty_qa_is_logged_and_counted(self, tmp_path: Path):
+        df = pd.DataFrame(
+            [
+                _row(
+                    "doc2.txt",
+                    qa_pairs=[],
+                    qa_generation_trace=[{"role": "assistant", "content": '{"pairs": []}'}],
+                )
+            ]
+        )
+        stats = log_stage0_raw_responses(df, num_pairs=2, batch_idx=0, output_dir=tmp_path)
+
+        assert stats["empty_qa_records"] == 1
+        assert stats["requested_qa_total"] == 2
+        assert stats["generated_qa_total"] == 0
+
+        entries = _read_jsonl(tmp_path / "stage0_raw_responses.jsonl")
+        assert entries[0]["status"] == "empty_qa"
+        assert entries[0]["requested_qa_pairs"] == 2
+        assert entries[0]["generated_qa_pairs"] == 0
+
+    def test_underfilled_qa_is_logged_and_counted(self, tmp_path: Path):
+        df = pd.DataFrame([_row("doc3.txt", qa_pairs=[{"question": "only one"}])])
+        stats = log_stage0_raw_responses(df, num_pairs=2, batch_idx=0, output_dir=tmp_path)
+
+        assert stats["underfilled_qa_records"] == 1
+        assert stats["empty_qa_records"] == 0
+        assert stats["requested_qa_total"] == 2
+        assert stats["generated_qa_total"] == 1
+
+        entries = _read_jsonl(tmp_path / "stage0_raw_responses.jsonl")
+        assert entries[0]["status"] == "underfilled_qa"
+
+    def test_mixed_batch_reports_correct_aggregate_counts(self, tmp_path: Path):
+        df = pd.DataFrame(
+            [
+                _row("doc0.txt"),  # healthy, full QA count
+                _row("doc1.txt", document_artifacts=None),  # parse failure
+                _row("doc2.txt", qa_pairs=[]),  # empty QA
+                _row("doc3.txt", qa_pairs=[{"question": "q1"}]),  # underfilled QA
+            ]
+        )
+        stats = log_stage0_raw_responses(df, num_pairs=2, batch_idx=0, output_dir=tmp_path)
+
+        assert stats["requested_records"] == 4
+        assert stats["persisted_records"] == 3
+        assert stats["omitted_by_column"]["document_artifacts"] == 1
+        assert stats["empty_qa_records"] == 1
+        assert stats["underfilled_qa_records"] == 1
+        # requested: 2 pairs x 4 records (qa_generation is present on all 4 rows,
+        # even doc1.txt whose *document_artifacts* column failed to parse)
+        assert stats["requested_qa_total"] == 8
+        # generated: 2 (doc0, healthy) + 2 (doc1, qa_generation itself succeeded)
+        #          + 0 (doc2, empty) + 1 (doc3, underfilled)
+        assert stats["generated_qa_total"] == 5
+
+        entries = _read_jsonl(tmp_path / "stage0_raw_responses.jsonl")
+        assert len(entries) == 3  # only the problematic records are logged
+        statuses = {entry["status"] for entry in entries}
+        assert statuses == {"omitted_parse_failure", "empty_qa", "underfilled_qa"}
+
+    def test_log_file_is_appended_across_batches(self, tmp_path: Path):
+        df_batch0 = pd.DataFrame([_row("doc0.txt", qa_pairs=[])])
+        df_batch1 = pd.DataFrame([_row("doc1.txt", document_artifacts=None)])
+
+        log_stage0_raw_responses(df_batch0, num_pairs=2, batch_idx=0, output_dir=tmp_path)
+        log_stage0_raw_responses(df_batch1, num_pairs=2, batch_idx=1, output_dir=tmp_path)
+
+        entries = _read_jsonl(tmp_path / "stage0_raw_responses.jsonl")
+        assert len(entries) == 2
+        assert entries[0]["batch_index"] == 0
+        assert entries[1]["batch_index"] == 1
+
+
+class TestMergeStage0Stats:
+    def test_accumulates_across_batches(self):
+        total = {
+            "requested_records": 0,
+            "persisted_records": 0,
+            "omitted_by_column": {},
+            "empty_qa_records": 0,
+            "underfilled_qa_records": 0,
+            "requested_qa_total": 0,
+            "generated_qa_total": 0,
+        }
+        batch_stats = {
+            "requested_records": 4,
+            "persisted_records": 3,
+            "omitted_by_column": {"document_artifacts": 1, "qa_generation": 0},
+            "empty_qa_records": 1,
+            "underfilled_qa_records": 1,
+            "requested_qa_total": 6,
+            "generated_qa_total": 3,
+        }
+
+        merged = _merge_stage0_stats(total, batch_stats)
+        merged = _merge_stage0_stats(merged, batch_stats)
+
+        assert merged["requested_records"] == 8
+        assert merged["persisted_records"] == 6
+        assert merged["omitted_by_column"]["document_artifacts"] == 2
+        assert merged["empty_qa_records"] == 2
+        assert merged["underfilled_qa_records"] == 2
+        assert merged["requested_qa_total"] == 12
+        assert merged["generated_qa_total"] == 6
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]


### PR DESCRIPTION
Fixes #314

## Summary

Stage 0 SDG (`retriever_sdg.pipeline`) generates `document_artifacts` and
`qa_generation` via `LLMStructuredColumnConfig`. When structured-output
parsing failed, or parsing produced empty/underfilled QA results, the raw
LLM response was never persisted — making root-cause analysis impossible.

This PR:

1. **Logs every raw LLM response before parsing.** Enables
   `with_trace=TraceType.LAST_MESSAGE` on the `document_artifacts` and
   `qa_generation` columns (a feature already supported by `data-designer`'s
   `LLMStructuredColumnConfig`), which captures the pre-parse assistant
   message in a `{column}__trace` field.

2. **Treats the configured QA count as a target, not a hard requirement.**
   A new `log_stage0_raw_responses()` helper runs after each batch's
   `load_dataset()` call and writes one JSONL entry per problematic
   `(record, column)` pair to `<output_dir>/stage0_raw_responses.jsonl`,
   including:
   - record index
   - generated column
   - attempt number
   - status (`omitted_parse_failure` / `empty_qa` / `underfilled_qa`)
   - requested vs. generated QA pair counts
   - the raw LLM response text

   Empty QA results are counted and logged rather than silently dropped;
   underfilled results are accepted but reported.

3. **Prints a Stage 0 completion summary** (per batch and for the overall
   run) via `print_stage0_batch_summary()`, showing:
   - requested vs. persisted records
   - omitted records by column
   - empty / underfilled QA counts
   - requested vs. generated QA totals and fill rate

## Example summary output

```
Stage 0 completion summary (batch 0):
  Requested records: 4
  Persisted records: 3
  Omitted records (document_artifacts, parse failure): 1
  Empty QA results: 1
  Underfilled QA results (< requested count): 1
  Requested QA pairs: 8
  Generated QA pairs: 5
  QA fill rate: 62.5%
```

## Files changed

- `src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/src/retriever_sdg/pipeline.py`
- `src/nemotron/recipes/embed/stage0_sdg/vendor/retriever-sdg/tests/test_stage0_logging.py` (new)

## Testing

Added unit tests covering:
- healthy records (no log entry produced)
- parse failures (missing/None generated column)
- empty QA results
- underfilled QA results
- mixed batches (aggregate counts)
- log file appending across multiple batches
- stats aggregation across batches (`_merge_stage0_stats`)

Ran locally against `data-designer==0.5.4` / `data-designer-config==0.5.4` /
`data-designer-engine==0.5.4` (the versions pinned in
`vendor/retriever-sdg/uv.lock`) in an isolated venv:

```
13 passed in 2.81s
```

Also verified `python -m py_compile` on the modified `pipeline.py`.

## Notes / follow-ups

- This does not change existing parsing/retry behavior in `data-designer`
  itself (out of scope — that's an external, closed-source dependency).
  Per the issue's "Alternatives Considered", automatically modifying model
  responses was explicitly ruled out due to lack of evidence; this PR is
  the evidence-gathering step.
- A future PR could add automatic retry-on-empty-QA using the newly logged
  raw responses to decide when a retry is worthwhile, but that's left for a
  follow-up once real failure data has been collected.
