### PR TITLE
fix(data_prep): keep SFT rows when chat template adds a trailing newline

### DIFF
--- a/src/nemotron/data_prep/core/chat_template.py
+++ b/src/nemotron/data_prep/core/chat_template.py
@@ -240,12 +240,19 @@ def split_template_into_messages(
             )
 
         current_pos = len(template_up_to_here)
-        chunk_text = full_template[previous_pos:current_pos]
 
-        # Verify incremental rendering matches full template
+        # Verify incremental rendering matches full template. Some chat templates
+        # append trailing whitespace after the generation prompt that isn't at the
+        # matching position in the full template (issue #184); re-align on the
+        # stripped prefix so those rows are kept instead of dropped.
         if template_up_to_here != full_template[:current_pos]:
-            raise ValueError(f"Template mismatch at message {i}: incremental rendering doesn't match full")
+            stripped = template_up_to_here.rstrip()
+            if stripped and stripped == full_template[: len(stripped)]:
+                current_pos = len(stripped)
+            else:
+                raise ValueError(f"Template mismatch at message {i}: incremental rendering doesn't match full")
 
+        chunk_text = full_template[previous_pos:current_pos]
         result.append({"role": messages[i]["role"], "content": chunk_text})
         previous_pos = current_pos
 

--- a/tests/data_prep/test_chat_template_trailing_newline.py
+++ b/tests/data_prep/test_chat_template_trailing_newline.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for issue #184.
+
+Some chat templates append a trailing newline after the generation prompt that
+is absent at the matching position in the full template. The strict prefix check
+in ``split_template_into_messages`` then failed and the row was dropped from the
+SFT dataset. The splitter must recover such rows without shifting chunk
+boundaries on templates that already line up.
+"""
+
+from __future__ import annotations
+
+from nemotron.data_prep.core.chat_template import split_template_into_messages
+
+MESSAGES = [
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "Hello"},
+]
+
+
+class _Tokenizer:
+    """Renders a full template cleanly but adds an extra newline after the
+    generation prompt, reproducing the issue #184 pathology when ``extra`` is set."""
+
+    def __init__(self, extra: str):
+        self._extra = extra
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, **kwargs):
+        out = "".join(f"<|im_start|>{m['role']}\n{m['content']}<|im_end|>\n" for m in messages)
+        if add_generation_prompt:
+            out += "<|im_start|>assistant\n" + self._extra
+        return out
+
+
+def test_trailing_newline_row_is_kept():
+    tokenizer = _Tokenizer(extra="\n")
+    full = tokenizer.apply_chat_template(MESSAGES)
+    chunks = split_template_into_messages(MESSAGES, tokenizer, start_from_last_user=False, enable_thinking=False)
+    assert [c["role"] for c in chunks] == ["user", "assistant"]
+    assert "".join(c["content"] for c in chunks) == full
+
+
+def test_clean_template_boundaries_unchanged():
+    tokenizer = _Tokenizer(extra="")
+    full = tokenizer.apply_chat_template(MESSAGES)
+    chunks = split_template_into_messages(MESSAGES, tokenizer, start_from_last_user=False, enable_thinking=False)
+    assert "".join(c["content"] for c in chunks) == full
+    assert chunks[-1]["content"].endswith("<|im_end|>\n")


### PR DESCRIPTION
## Description

Fixes #184

When preparing data for SFT, a large fraction of rows were being filtered out. Some chat templates emit a trailing newline after the generation prompt that is **not** present at the matching position in the full template. The strict prefix check in `split_template_into_messages` then failed (`Template mismatch at message N`) and the whole row was dropped from the dataset.

## Fix

When the strict check fails, re-align on the stripped prefix instead of dropping the row. The fallback only fires on a mismatch, so templates that already line up keep byte-identical chunk boundaries — clean rows are unaffected.

This is a minimal, targeted version of the fix suggested in the issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `tests/data_prep/test_chat_template_trailing_newline.py`:
- a template with the issue #184 trailing-newline pathology is now kept and reconstructs the full template;
- a clean template keeps identical chunk boundaries (no drift).