### PR TITLE
Allow dataset subsets to be specified

### DIFF
--- a/src/nemotron/data_prep/recipes/rl.py
+++ b/src/nemotron/data_prep/recipes/rl.py
@@ -196,7 +196,10 @@ def setup_rl_run(
         dataset_path = dataset_path[5:]
 
     # Discover available splits from HF
-    available_splits = get_dataset_split_names(dataset_path)
+    available_splits = get_dataset_split_names(
+        dataset_path,
+        config_name=dataset.subset,
+    )
 
     # Normalize split names for output directories
     split_name_mapping = {

--- a/tests/data_prep/test_jsonl_pipeline.py
+++ b/tests/data_prep/test_jsonl_pipeline.py
@@ -112,6 +112,41 @@ class TestJsonlDatasetWorkItem:
         assert item.subset is None
 
 
+class TestSetupRlRun:
+    """Tests for RL run setup and Hugging Face split discovery."""
+
+    def test_passes_subset_as_hf_config_name(self, tmp_path: Path) -> None:
+        from nemotron.data_prep.blend import DataBlend, Dataset
+        from nemotron.data_prep.recipes.rl import setup_rl_run
+
+        blend = DataBlend.from_datasets(
+            Dataset(
+                name="arc-agi",
+                path="hf://nvidia/Nemotron-RL-ARC-AGI-v1",
+                split="train",
+                subset="transductive",
+            )
+        )
+
+        with patch("datasets.get_dataset_split_names", return_value=["train"]) as get_splits:
+            items, _, _, _, available_splits = setup_rl_run(
+                blend=blend,
+                output_dir=tmp_path,
+                sample=None,
+                force=False,
+                compression="none",
+                num_shards_per_split=1,
+                resolve_hf_placeholders=False,
+            )
+
+        get_splits.assert_called_once_with(
+            "nvidia/Nemotron-RL-ARC-AGI-v1",
+            config_name="transductive",
+        )
+        assert available_splits == ["train"]
+        assert items[0].subset == "transductive"
+
+
 class TestJsonlShardWorkItem:
     """Tests for JsonlShardWorkItem (with plan_hash field)."""
 


### PR DESCRIPTION
## Description

Fixed an issue where attempting to run data prep targeting a Hugging Face dataset with subsets would result in an error that the config_name could not be found while downloading the dataset. The default behaviour is to assume no subset and download the split if specified. "subset" must be in the data blend file if the dataset has subsets.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement
- [ ] New training recipe or step

## Changes Made

- Allow subsets to be specified in the data blend file

## Testing

Add the following to `src/nemotron/recipes/lightning35/stage2_rl/config/data_prep/data_blend_raw.json`:
```json
{
  "datasets": [
    {
      "name": "nemotron-3.5-lightning-rl-arc-agi-v1",
      "path": "hf://nvidia/Nemotron-RL-ARC-AGI-v1",
      "split": "train",
      "weight": 1.0,
      "subset": "python_inductive"
    }
  ]
}
```

Prepare the dataset with:
```bash
uv run --extra xenna nemotron lightning35 data prep rl
```

## Checklist

- [x] My code follows the existing style conventions (ruff + ruff-format)
- [x] I have added type hints and docstrings where applicable
- [x] I have added tests for new functionality
- [x] All existing and new tests pass
- [x] I have updated documentation where needed
- [x] My commits are signed off (`git commit -s`) per the DCO

## Additional Notes

N/A