### PR TITLE
fix(retrieval): preserve SDG integration contracts

### DIFF
--- a/docs/nemotron/embed/README.md
+++ b/docs/nemotron/embed/README.md
@@ -243,6 +243,12 @@ the contents of corpus files. Use `always` or `if_possible` only when the input 
 has not changed in place. The default is `never` so that an ordinary repeated recipe
 invocation generates new data instead of silently reusing a completed dataset.
 
+After every successful non-preview run, Stage 0 writes `generation_result.json`
+next to the exported JSONL. The default Stage 1 profile reads this manifest so it
+uses the exact output returned by that run, including a timestamped output from a
+repeated `resume=never` invocation. An explicit `sdg_input_path` still takes
+precedence and is passed through unchanged.
+
 Earlier recipe versions exposed `batch_size`, `start_batch_index`, and
 `end_batch_index` for manually partitioning the corpus into independent runs. Those
 settings have been removed with the manual batching implementation. Use `buffer_size`

--- a/docs/nemotron/embed/README.md
+++ b/docs/nemotron/embed/README.md
@@ -243,11 +243,12 @@ the contents of corpus files. Use `always` or `if_possible` only when the input 
 has not changed in place. The default is `never` so that an ordinary repeated recipe
 invocation generates new data instead of silently reusing a completed dataset.
 
-After every successful non-preview run, Stage 0 writes `generation_result.json`
-next to the exported JSONL. The default Stage 1 profile reads this manifest so it
-uses the exact output returned by that run, including a timestamped output from a
-repeated `resume=never` invocation. An explicit `sdg_input_path` still takes
-precedence and is passed through unchanged.
+After each successful non-preview run, Stage 0 writes `generation_result.json`
+next to the exported JSONL file. This manifest identifies the exact output from
+the run, including a timestamped file from a repeated `resume=never` invocation.
+By default, Stage 1 resolves the manifest before preparing the data. To select
+another input, set `sdg_input_path` to a data file or an existing SDG output
+directory.
 
 Earlier recipe versions exposed `batch_size`, `start_batch_index`, and
 `end_batch_index` for manually partitioning the corpus into independent runs. Those
@@ -622,7 +623,7 @@ Model: fine-tuned
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| Data Designer retrieval SDG plugin | Synthetic data generation and retriever-data conversion | [GitHub](https://github.com/NVIDIA-NeMo/DataDesignerPlugins/tree/main/plugins/data-designer-retrieval-sdg) |
+| Data Designer retrieval SDG plugin | Generate synthetic question-and-answer pairs and convert them to training data | [Plugin source](https://github.com/NVIDIA-NeMo/DataDesignerPlugins/tree/main/plugins/data-designer-retrieval-sdg) |
 | Automodel | Embedding model training framework | [GitHub](https://github.com/NVIDIA/NeMo-Automodel) |
 | BEIR | Evaluation framework for information retrieval | [GitHub](https://github.com/beir-cellar/beir) |
 | NeMo Export-Deploy | ONNX/TensorRT export for optimized inference | [GitHub](https://github.com/NVIDIA/NeMo-Export-Deploy) |

--- a/docs/nemotron/rerank/README.md
+++ b/docs/nemotron/rerank/README.md
@@ -289,10 +289,12 @@ nemotron rerank finetune -c default
 nemotron rerank eval -c default
 ```
 
-For generated data, Stage 0 writes `generation_result.json` after each successful
-non-preview run. The default Stage 1 profile resolves that manifest to the exact
-JSONL returned by Stage 0, including timestamped outputs from repeated fresh runs.
-Pass an explicit `sdg_input_path` to prepare a different file or legacy directory.
+After each successful non-preview run, Stage 0 writes `generation_result.json`
+next to the exported JSONL file. This manifest identifies the exact output from
+the run, including a timestamped file from a repeated `resume=never` invocation.
+By default, Stage 1 resolves the manifest before preparing the data. To select
+another input, set `sdg_input_path` to a data file or an existing SDG output
+directory.
 
 ## Execution Modes
 
@@ -615,7 +617,7 @@ After running the full pipeline:
 ```
 output/rerank/
 ├── stage0_sdg/                    # Synthetic Q&A pairs
-│   ├── generation_result.json     # Exact latest successful-run handoff
+│   ├── generation_result.json     # Latest successful Stage 0 output manifest
 │   ├── *.jsonl                    # Generated datasets (timestamped when needed)
 │   └── artifacts/                 # Data Designer checkpoints and provenance
 ├── stage1_prep/                   # Training-ready data
@@ -654,7 +656,7 @@ Higher scores indicate better re-ranking performance. The key metric to watch is
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| Retrieval SDG plugin | Released Data Designer generation and conversion plugin | [GitHub](https://github.com/NVIDIA-NeMo/DataDesignerPlugins) |
+| Data Designer retrieval SDG plugin | Generate synthetic question-and-answer pairs and convert them to training data | [Plugin source](https://github.com/NVIDIA-NeMo/DataDesignerPlugins/tree/main/plugins/data-designer-retrieval-sdg) |
 | Automodel | Cross-encoder model training framework | [GitHub](https://github.com/NVIDIA-NeMo/Automodel) |
 | BEIR | Evaluation framework for information retrieval | [GitHub](https://github.com/beir-cellar/beir) |
 | NeMo Export-Deploy | ONNX/TensorRT export for optimized inference | [GitHub](https://github.com/NVIDIA-NeMo/Export-Deploy) |

--- a/docs/nemotron/rerank/README.md
+++ b/docs/nemotron/rerank/README.md
@@ -35,7 +35,7 @@ The two models are complementary — use the embedding model to cast a wide net,
                                    │
                                    ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│              STAGE 0: SYNTHETIC DATA GENERATION (retriever-sdg)             │
+│           STAGE 0: SYNTHETIC DATA GENERATION (retrieval SDG plugin)          │
 │  ┌─────────────────┐    ┌─────────────────┐    ┌──────────────────────────┐ │
 │  │ Document Chunks │ →  │  LLM Generation │ →  │ Q&A Pairs + Evaluations  │ │
 │  │                 │    │  (NVIDIA API)   │    │                          │ │
@@ -278,16 +278,21 @@ If you want to fine-tune a reranking model on NVIDIA-related content, you can **
 python -c "
 from datasets import load_dataset
 ds = load_dataset('nvidia/Retrieval-Synthetic-NVDocs-v1', split='train')
-ds.to_json('./output/rerank/stage0_sdg/nv_docs_sdg.json')
+ds.to_json('./output/rerank/stage0_sdg/nv_docs_sdg.jsonl')
 "
 
 # Start from Stage 1 (data preparation) using the downloaded data
-nemotron rerank prep -c default sdg_input_path=./output/rerank/stage0_sdg
+nemotron rerank prep -c default sdg_input_path=./output/rerank/stage0_sdg/nv_docs_sdg.jsonl
 
 # Continue with the rest of the pipeline
 nemotron rerank finetune -c default
 nemotron rerank eval -c default
 ```
+
+For generated data, Stage 0 writes `generation_result.json` after each successful
+non-preview run. The default Stage 1 profile resolves that manifest to the exact
+JSONL returned by Stage 0, including timestamped outputs from repeated fresh runs.
+Pass an explicit `sdg_input_path` to prepare a different file or legacy directory.
 
 ## Execution Modes
 
@@ -527,7 +532,7 @@ nemotron rerank info
 nemotron rerank sdg -c default corpus_dir=/path/to/docs
 
 # Prepare training data (convert, mine, unroll)
-nemotron rerank prep -c default sdg_input_path=/path/to/sdg
+nemotron rerank prep -c default sdg_input_path=/path/to/generated.jsonl
 ```
 
 ### Training
@@ -610,7 +615,9 @@ After running the full pipeline:
 ```
 output/rerank/
 ├── stage0_sdg/                    # Synthetic Q&A pairs
-│   └── generated_batch*.json
+│   ├── generation_result.json     # Exact latest successful-run handoff
+│   ├── *.jsonl                    # Generated datasets (timestamped when needed)
+│   └── artifacts/                 # Data Designer checkpoints and provenance
 ├── stage1_prep/                   # Training-ready data
 │   ├── train.json                 # Original training data
 │   ├── train_mined.automodel.json # With hard negatives
@@ -647,7 +654,7 @@ Higher scores indicate better re-ranking performance. The key metric to watch is
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| retriever-sdg | Synthetic data generation using NeMo Data Designer | [GitHub](https://github.com/NVIDIA-NeMo/DataDesigner) |
+| Retrieval SDG plugin | Released Data Designer generation and conversion plugin | [GitHub](https://github.com/NVIDIA-NeMo/DataDesignerPlugins) |
 | Automodel | Cross-encoder model training framework | [GitHub](https://github.com/NVIDIA-NeMo/Automodel) |
 | BEIR | Evaluation framework for information retrieval | [GitHub](https://github.com/beir-cellar/beir) |
 | NeMo Export-Deploy | ONNX/TensorRT export for optimized inference | [GitHub](https://github.com/NVIDIA-NeMo/Export-Deploy) |

--- a/src/nemotron/recipes/embed/README.md
+++ b/src/nemotron/recipes/embed/README.md
@@ -243,6 +243,12 @@ the contents of corpus files. Use `always` or `if_possible` only when the input 
 has not changed in place. The default is `never` so that an ordinary repeated recipe
 invocation generates new data instead of silently reusing a completed dataset.
 
+After every successful non-preview run, Stage 0 writes `generation_result.json`
+next to the exported JSONL. The default Stage 1 profile reads this manifest so it
+uses the exact output returned by that run, including a timestamped output from a
+repeated `resume=never` invocation. An explicit `sdg_input_path` still takes
+precedence and is passed through unchanged.
+
 Earlier recipe versions exposed `batch_size`, `start_batch_index`, and
 `end_batch_index` for manually partitioning the corpus into independent runs. Those
 settings have been removed with the manual batching implementation. Use `buffer_size`

--- a/src/nemotron/recipes/embed/README.md
+++ b/src/nemotron/recipes/embed/README.md
@@ -243,11 +243,12 @@ the contents of corpus files. Use `always` or `if_possible` only when the input 
 has not changed in place. The default is `never` so that an ordinary repeated recipe
 invocation generates new data instead of silently reusing a completed dataset.
 
-After every successful non-preview run, Stage 0 writes `generation_result.json`
-next to the exported JSONL. The default Stage 1 profile reads this manifest so it
-uses the exact output returned by that run, including a timestamped output from a
-repeated `resume=never` invocation. An explicit `sdg_input_path` still takes
-precedence and is passed through unchanged.
+After each successful non-preview run, Stage 0 writes `generation_result.json`
+next to the exported JSONL file. This manifest identifies the exact output from
+the run, including a timestamped file from a repeated `resume=never` invocation.
+By default, Stage 1 resolves the manifest before preparing the data. To select
+another input, set `sdg_input_path` to a data file or an existing SDG output
+directory.
 
 Earlier recipe versions exposed `batch_size`, `start_batch_index`, and
 `end_batch_index` for manually partitioning the corpus into independent runs. Those
@@ -623,7 +624,7 @@ Model: fine-tuned
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| Data Designer retrieval SDG plugin | Synthetic data generation and retriever-data conversion | [GitHub](https://github.com/NVIDIA-NeMo/DataDesignerPlugins/tree/main/plugins/data-designer-retrieval-sdg) |
+| Data Designer retrieval SDG plugin | Generate synthetic question-and-answer pairs and convert them to training data | [Plugin source](https://github.com/NVIDIA-NeMo/DataDesignerPlugins/tree/main/plugins/data-designer-retrieval-sdg) |
 | Automodel | Embedding model training framework | [GitHub](https://github.com/NVIDIA/NeMo-Automodel) |
 | BEIR | Evaluation framework for information retrieval | [GitHub](https://github.com/beir-cellar/beir) |
 | NeMo Export-Deploy | ONNX/TensorRT export for optimized inference | [GitHub](https://github.com/NVIDIA/NeMo-Export-Deploy) |

--- a/src/nemotron/recipes/embed/sdg_manifest.py
+++ b/src/nemotron/recipes/embed/sdg_manifest.py
@@ -1,0 +1,88 @@
+"""Stable handoff between retrieval SDG generation and data preparation."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+GENERATION_MANIFEST_FILENAME = "generation_result.json"
+GENERATION_MANIFEST_SCHEMA_VERSION = 1
+
+
+def write_generation_manifest(
+    *,
+    output_dir: Path,
+    output_path: Path,
+    dataset_name: str,
+) -> Path:
+    """Atomically publish the exact output of a successful generation run."""
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    resolved_output = output_path.resolve()
+    if not resolved_output.is_file():
+        raise FileNotFoundError(f"Generation output does not exist: {resolved_output}")
+    if not dataset_name:
+        raise ValueError("dataset_name must not be empty")
+
+    try:
+        stored_output = str(resolved_output.relative_to(output_dir))
+    except ValueError:
+        stored_output = str(resolved_output)
+
+    payload = {
+        "schema_version": GENERATION_MANIFEST_SCHEMA_VERSION,
+        "dataset_name": dataset_name,
+        "output_path": stored_output,
+    }
+    manifest_path = output_dir / GENERATION_MANIFEST_FILENAME
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=output_dir,
+        prefix=f".{GENERATION_MANIFEST_FILENAME}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
+            json.dump(payload, temporary_file, indent=2, sort_keys=True)
+            temporary_file.write("\n")
+        temporary_path.replace(manifest_path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return manifest_path
+
+
+def resolve_generation_input(input_path: Path) -> Path:
+    """Resolve a generation-result manifest, preserving explicit data paths."""
+    input_path = input_path.resolve()
+    if input_path.name != GENERATION_MANIFEST_FILENAME:
+        return input_path
+
+    try:
+        payload = json.loads(input_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Invalid generation manifest: {input_path}") from exc
+
+    if payload.get("schema_version") != GENERATION_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(f"Unsupported generation manifest schema in {input_path}: {payload.get('schema_version')!r}")
+
+    stored_output = payload.get("output_path")
+    dataset_name = payload.get("dataset_name")
+    if not isinstance(stored_output, str) or not stored_output:
+        raise ValueError(f"Generation manifest has no output_path: {input_path}")
+    if not isinstance(dataset_name, str) or not dataset_name:
+        raise ValueError(f"Generation manifest has no dataset_name: {input_path}")
+
+    output_path = Path(stored_output)
+    if not output_path.is_absolute():
+        output_path = input_path.parent / output_path
+    output_path = output_path.resolve()
+    if not output_path.is_file():
+        raise FileNotFoundError(f"Generation output referenced by {input_path} does not exist: {output_path}")
+
+    return output_path

--- a/src/nemotron/recipes/embed/stage0_sdg/data_prep.py
+++ b/src/nemotron/recipes/embed/stage0_sdg/data_prep.py
@@ -416,6 +416,7 @@ def run_sdg(cfg: SDGConfig) -> Path:
     Returns:
         Exact JSONL output path, or the configured output directory for preview.
     """
+    from nemotron.recipes.embed.sdg_manifest import write_generation_manifest
     from nemotron.recipes.embed.stage0_sdg.plugin_adapter import execute_generation
 
     # Resolve corpus_dir (handles hf:// URIs and local paths)
@@ -524,8 +525,15 @@ def run_sdg(cfg: SDGConfig) -> Path:
         print(f"   Preview records: {result.num_preview_records}")
         return output_dir
 
+    manifest_path = write_generation_manifest(
+        output_dir=output_dir,
+        output_path=result.output_path,
+        dataset_name=result.dataset_name,
+    )
+
     print("\nSynthetic data generation complete!")
     print(f"   Output: {result.output_path}")
+    print(f"   Handoff: {manifest_path}")
     print(f"   Dataset: {result.dataset_name}")
     print(f"   Records: {result.num_records}")
     if result.resolved_config_path:

--- a/src/nemotron/recipes/embed/stage1_data_prep/config/default.yaml
+++ b/src/nemotron/recipes/embed/stage1_data_prep/config/default.yaml
@@ -26,8 +26,8 @@ artifact_root: ./output/embed/nemotron-3-1b
 # Corpus identifier
 corpus_id: nv_pp_random
 
-# Exact Stage 0 JSONL output (mutually exclusive with train_input_file)
-sdg_input_path: ${artifact_root}/stage0_sdg/nv_pp_random.jsonl
+# Stage 0 result manifest; resolves the exact JSONL produced by the latest successful run
+sdg_input_path: ${artifact_root}/stage0_sdg/generation_result.json
 
 # Output directory for prepared training data
 output_dir: ${artifact_root}/stage1_data_prep

--- a/src/nemotron/recipes/embed/stage1_data_prep/config/llama.yaml
+++ b/src/nemotron/recipes/embed/stage1_data_prep/config/llama.yaml
@@ -27,8 +27,8 @@ artifact_root: ./output/embed
 # Corpus identifier
 corpus_id: nv_pp_random
 
-# Exact Stage 0 JSONL output (mutually exclusive with train_input_file)
-sdg_input_path: ${artifact_root}/stage0_sdg/nv_pp_random.jsonl
+# Stage 0 result manifest; resolves the exact JSONL produced by the latest successful run
+sdg_input_path: ${artifact_root}/stage0_sdg/generation_result.json
 
 # Output directory for prepared training data
 output_dir: ${artifact_root}/stage1_data_prep

--- a/src/nemotron/recipes/embed/stage1_data_prep/data_prep.py
+++ b/src/nemotron/recipes/embed/stage1_data_prep/data_prep.py
@@ -90,8 +90,8 @@ class DataPrepConfig(RecipeSettings):
 
     corpus_id: str = Field(default="nv_pp_random", description="Corpus identifier (used for output naming).")
     sdg_input_path: Path | None = Field(
-        default_factory=lambda data: data["artifact_root"] / "stage0_sdg/nv_pp_random.jsonl",
-        description="Exact SDG output file, or an explicit legacy input path.",
+        default_factory=lambda data: data["artifact_root"] / "stage0_sdg/generation_result.json",
+        description="Stage 0 generation-result manifest, exact SDG output file, or explicit legacy input path.",
     )
     train_input_file: Path | None = Field(
         default=None, description="Path to pre-converted training file (skips SDG conversion)."
@@ -285,10 +285,27 @@ def run_data_prep(cfg: DataPrepConfig) -> Path:
     Returns:
         Path to final training data file.
     """
+    configured_sdg_input = cfg.sdg_input_path
+    if configured_sdg_input:
+        from nemotron.recipes.embed.sdg_manifest import resolve_generation_input
+
+        try:
+            resolved_sdg_input = resolve_generation_input(configured_sdg_input)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            print(
+                "       Please run stage0_sdg first, or provide an explicit sdg_input_path.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        cfg = cfg.model_copy(update={"sdg_input_path": resolved_sdg_input})
+
     print("📋 Data Preparation Pipeline")
     print("=" * 60)
     print(f"Corpus ID:      {cfg.corpus_id}")
     if cfg.sdg_input_path:
+        if configured_sdg_input != cfg.sdg_input_path:
+            print(f"SDG Handoff:    {configured_sdg_input}")
         print(f"SDG Input:      {cfg.sdg_input_path}")
     else:
         print(f"Train Input:    {cfg.train_input_file}")

--- a/src/nemotron/recipes/embed/stage1_data_prep/plugin_adapter.py
+++ b/src/nemotron/recipes/embed/stage1_data_prep/plugin_adapter.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from nemotron.recipes.embed.sdg_manifest import resolve_generation_input
+
 if TYPE_CHECKING:
     from data_designer_retrieval_sdg import ConversionResult, ConversionRunConfig
 
@@ -21,7 +23,7 @@ def build_conversion_config(cfg: DataPrepConfig) -> ConversionRunConfig:
 
     return ConversionRunConfig(
         schema_version=RETRIEVAL_SDG_SCHEMA_VERSION,
-        input_path=cfg.sdg_input_path.resolve(),
+        input_path=resolve_generation_input(cfg.sdg_input_path),
         corpus_id=cfg.corpus_id,
         output_dir=cfg.output_dir.resolve(),
         eval_only=False,

--- a/src/nemotron/recipes/rerank/README.md
+++ b/src/nemotron/recipes/rerank/README.md
@@ -289,10 +289,12 @@ nemotron rerank finetune -c default
 nemotron rerank eval -c default
 ```
 
-For generated data, Stage 0 writes `generation_result.json` after each successful
-non-preview run. The default Stage 1 profile resolves that manifest to the exact
-JSONL returned by Stage 0, including timestamped outputs from repeated fresh runs.
-Pass an explicit `sdg_input_path` to prepare a different file or legacy directory.
+After each successful non-preview run, Stage 0 writes `generation_result.json`
+next to the exported JSONL file. This manifest identifies the exact output from
+the run, including a timestamped file from a repeated `resume=never` invocation.
+By default, Stage 1 resolves the manifest before preparing the data. To select
+another input, set `sdg_input_path` to a data file or an existing SDG output
+directory.
 
 ## Execution Modes
 
@@ -615,7 +617,7 @@ After running the full pipeline:
 ```
 output/rerank/
 ├── stage0_sdg/                    # Synthetic Q&A pairs
-│   ├── generation_result.json     # Exact latest successful-run handoff
+│   ├── generation_result.json     # Latest successful Stage 0 output manifest
 │   ├── *.jsonl                    # Generated datasets (timestamped when needed)
 │   └── artifacts/                 # Data Designer checkpoints and provenance
 ├── stage1_prep/                   # Training-ready data
@@ -654,7 +656,7 @@ Higher scores indicate better re-ranking performance. The key metric to watch is
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| Retrieval SDG plugin | Released Data Designer generation and conversion plugin | [GitHub](https://github.com/NVIDIA-NeMo/DataDesignerPlugins) |
+| Data Designer retrieval SDG plugin | Generate synthetic question-and-answer pairs and convert them to training data | [Plugin source](https://github.com/NVIDIA-NeMo/DataDesignerPlugins/tree/main/plugins/data-designer-retrieval-sdg) |
 | Automodel | Cross-encoder model training framework | [GitHub](https://github.com/NVIDIA-NeMo/Automodel) |
 | BEIR | Evaluation framework for information retrieval | [GitHub](https://github.com/beir-cellar/beir) |
 | NeMo Export-Deploy | ONNX/TensorRT export for optimized inference | [GitHub](https://github.com/NVIDIA-NeMo/Export-Deploy) |

--- a/src/nemotron/recipes/rerank/README.md
+++ b/src/nemotron/recipes/rerank/README.md
@@ -35,7 +35,7 @@ The two models are complementary — use the embedding model to cast a wide net,
                                    │
                                    ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│              STAGE 0: SYNTHETIC DATA GENERATION (retriever-sdg)             │
+│           STAGE 0: SYNTHETIC DATA GENERATION (retrieval SDG plugin)          │
 │  ┌─────────────────┐    ┌─────────────────┐    ┌──────────────────────────┐ │
 │  │ Document Chunks │ →  │  LLM Generation │ →  │ Q&A Pairs + Evaluations  │ │
 │  │                 │    │  (NVIDIA API)   │    │                          │ │
@@ -278,16 +278,21 @@ If you want to fine-tune a reranking model on NVIDIA-related content, you can **
 python -c "
 from datasets import load_dataset
 ds = load_dataset('nvidia/Retrieval-Synthetic-NVDocs-v1', split='train')
-ds.to_json('./output/rerank/stage0_sdg/nv_docs_sdg.json')
+ds.to_json('./output/rerank/stage0_sdg/nv_docs_sdg.jsonl')
 "
 
 # Start from Stage 1 (data preparation) using the downloaded data
-nemotron rerank prep -c default sdg_input_path=./output/rerank/stage0_sdg
+nemotron rerank prep -c default sdg_input_path=./output/rerank/stage0_sdg/nv_docs_sdg.jsonl
 
 # Continue with the rest of the pipeline
 nemotron rerank finetune -c default
 nemotron rerank eval -c default
 ```
+
+For generated data, Stage 0 writes `generation_result.json` after each successful
+non-preview run. The default Stage 1 profile resolves that manifest to the exact
+JSONL returned by Stage 0, including timestamped outputs from repeated fresh runs.
+Pass an explicit `sdg_input_path` to prepare a different file or legacy directory.
 
 ## Execution Modes
 
@@ -527,7 +532,7 @@ nemotron rerank info
 nemotron rerank sdg -c default corpus_dir=/path/to/docs
 
 # Prepare training data (convert, mine, unroll)
-nemotron rerank prep -c default sdg_input_path=/path/to/sdg
+nemotron rerank prep -c default sdg_input_path=/path/to/generated.jsonl
 ```
 
 ### Training
@@ -610,7 +615,9 @@ After running the full pipeline:
 ```
 output/rerank/
 ├── stage0_sdg/                    # Synthetic Q&A pairs
-│   └── generated_batch*.json
+│   ├── generation_result.json     # Exact latest successful-run handoff
+│   ├── *.jsonl                    # Generated datasets (timestamped when needed)
+│   └── artifacts/                 # Data Designer checkpoints and provenance
 ├── stage1_prep/                   # Training-ready data
 │   ├── train.json                 # Original training data
 │   ├── train_mined.automodel.json # With hard negatives
@@ -647,7 +654,7 @@ Higher scores indicate better re-ranking performance. The key metric to watch is
 
 | Component | Purpose | Repository |
 |-----------|---------|------------|
-| retriever-sdg | Synthetic data generation using NeMo Data Designer | [GitHub](https://github.com/NVIDIA-NeMo/DataDesigner) |
+| Retrieval SDG plugin | Released Data Designer generation and conversion plugin | [GitHub](https://github.com/NVIDIA-NeMo/DataDesignerPlugins) |
 | Automodel | Cross-encoder model training framework | [GitHub](https://github.com/NVIDIA-NeMo/Automodel) |
 | BEIR | Evaluation framework for information retrieval | [GitHub](https://github.com/beir-cellar/beir) |
 | NeMo Export-Deploy | ONNX/TensorRT export for optimized inference | [GitHub](https://github.com/NVIDIA-NeMo/Export-Deploy) |

--- a/src/nemotron/recipes/rerank/stage0_sdg/config/default.yaml
+++ b/src/nemotron/recipes/rerank/stage0_sdg/config/default.yaml
@@ -1,6 +1,6 @@
 # Stage 0: Synthetic Data Generation Configuration (Rerank)
 #
-# Generates synthetic Q&A pairs from document corpus using retriever-sdg.
+# Generates synthetic Q&A pairs using the released retrieval SDG plugin.
 # Uses the same SDG pipeline as the embed recipe but outputs to rerank directory.
 #
 # Usage:
@@ -26,15 +26,30 @@ num_sections: 1
 
 # Generation parameters
 max_artifacts_per_type: 2
-num_pairs: 10
+num_pairs: 7
+query_counts:
+  multi_hop: 3
+  structural: 2
+  contextual: 2
 min_hops: 1
 max_hops: 3
+reasoning_counts:
+  factual: 1
+  relational: 1
+  inferential: 1
+  temporal: 1
+  procedural: 1
+  causal: 1
+  visual: 1
 min_complexity: 2
+similarity_threshold: 0.9
 
-# Batch processing
-batch_size: 200
-start_batch_index: 0
-end_batch_index: -1
+# Data Designer execution
+dataset_name: nv_pp_random
+buffer_size: 200
+# Start fresh by default. Use always to require a compatible checkpoint, or
+# if_possible to resume when compatible and otherwise start fresh.
+resume: never
 
 # Multi-document bundling
 multi_doc: false

--- a/src/nemotron/recipes/rerank/stage1_prep/config/default.yaml
+++ b/src/nemotron/recipes/rerank/stage1_prep/config/default.yaml
@@ -20,8 +20,8 @@ run:
 # Corpus identifier
 corpus_id: nv_pp_random
 
-# Path to SDG output directory (from rerank sdg stage)
-sdg_input_path: ${oc.env:NEMO_RUN_DIR,.}/output/rerank/stage0_sdg
+# Stage 0 result manifest; resolves the exact JSONL produced by the latest successful run
+sdg_input_path: ${oc.env:NEMO_RUN_DIR,.}/output/rerank/stage0_sdg/generation_result.json
 
 # Output directory for prepared training data
 output_dir: ${oc.env:NEMO_RUN_DIR,.}/output/rerank/stage1_prep

--- a/tests/recipes/embed/test_profiles.py
+++ b/tests/recipes/embed/test_profiles.py
@@ -225,7 +225,7 @@ def test_artifact_root_override_rehomes_default_pipeline() -> None:
     assert sdg.artifact_root == artifact_root
     assert sdg.output_dir == artifact_root / "stage0_sdg"
     assert sdg.artifact_path == artifact_root / "stage0_sdg/artifacts"
-    assert prep.sdg_input_path == sdg.output_dir / "nv_pp_random.jsonl"
+    assert prep.sdg_input_path == sdg.output_dir / "generation_result.json"
     assert prep.output_dir == artifact_root / "stage1_data_prep"
     assert finetune.train_data_path == prep.output_dir / "train_mined.automodel_unrolled.json"
     assert finetune.checkpoint_dir == artifact_root / "stage2_finetune/checkpoints"
@@ -248,7 +248,7 @@ def test_default_profile_is_ministral_with_direct_checkpoint_deploy() -> None:
     assert sdg.output_dir == Path("output/embed/nemotron-3-1b/stage0_sdg")
     assert sdg.artifact_extraction_model == "nvidia/nemotron-3-ultra-550b-a55b"
     assert prep.base_model == BASE_MODEL
-    assert prep.sdg_input_path == sdg.output_dir / "nv_pp_random.jsonl"
+    assert prep.sdg_input_path == sdg.output_dir / "generation_result.json"
     assert finetune.base_model == BASE_MODEL
     assert prep.query_prefix == "query: "
     assert prep.passage_prefix == "passage: "

--- a/tests/recipes/embed/test_sdg_handoff.py
+++ b/tests/recipes/embed/test_sdg_handoff.py
@@ -1,0 +1,164 @@
+"""Allium-derived integration tests for the Stage 0 to Stage 1 handoff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from data_designer.engine.storage.artifact_storage import ArtifactStorage
+
+pytest.importorskip("data_designer_retrieval_sdg")
+
+from nemotron.recipes.embed.sdg_manifest import (
+    GENERATION_MANIFEST_FILENAME,
+    resolve_generation_input,
+    write_generation_manifest,
+)
+from nemotron.recipes.embed.stage0_sdg.data_prep import SDGConfig, run_sdg
+from nemotron.recipes.embed.stage1_data_prep.data_prep import DataPrepConfig
+from nemotron.recipes.embed.stage1_data_prep.plugin_adapter import build_conversion_config
+
+
+def _touch_jsonl(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+    return path
+
+
+def test_default_preparation_selects_first_generation_result(tmp_path: Path) -> None:
+    stage0 = SDGConfig(artifact_root=tmp_path, dataset_name="nv_pp_random")
+    output_path = _touch_jsonl(stage0.output_dir / "nv_pp_random.jsonl")
+    manifest_path = write_generation_manifest(
+        output_dir=stage0.output_dir,
+        output_path=output_path,
+        dataset_name="nv_pp_random",
+    )
+
+    stage1 = DataPrepConfig(artifact_root=tmp_path)
+    package_config = build_conversion_config(stage1)
+
+    assert stage1.sdg_input_path == manifest_path
+    assert package_config.input_path == output_path.resolve()
+
+
+def test_repeated_fresh_generation_replaces_latest_handoff(tmp_path: Path) -> None:
+    stage0 = SDGConfig(artifact_root=tmp_path, dataset_name="nv_pp_random", resume="never")
+    first_output = _touch_jsonl(stage0.output_dir / "nv_pp_random.jsonl")
+    manifest_path = write_generation_manifest(
+        output_dir=stage0.output_dir,
+        output_path=first_output,
+        dataset_name="nv_pp_random",
+    )
+
+    prior_artifacts = stage0.artifact_path / stage0.dataset_name
+    prior_artifacts.mkdir(parents=True)
+    (prior_artifacts / "metadata.json").write_text("{}", encoding="utf-8")
+    storage = ArtifactStorage(
+        artifact_path=stage0.artifact_path,
+        dataset_name=stage0.dataset_name,
+        resume=stage0.resume,
+    )
+    repeated_output = _touch_jsonl(stage0.output_dir / f"{storage.resolved_dataset_name}.jsonl")
+
+    write_generation_manifest(
+        output_dir=stage0.output_dir,
+        output_path=repeated_output,
+        dataset_name=storage.resolved_dataset_name,
+    )
+
+    assert resolve_generation_input(manifest_path) == repeated_output.resolve()
+
+
+@pytest.mark.parametrize("resume", ["always", "if_possible"])
+def test_resumed_generation_publishes_exact_result(tmp_path: Path, resume: str) -> None:
+    stage0 = SDGConfig(artifact_root=tmp_path, dataset_name="nv_pp_random", resume=resume)
+    output_path = _touch_jsonl(stage0.output_dir / "nv_pp_random.jsonl")
+
+    manifest_path = write_generation_manifest(
+        output_dir=stage0.output_dir,
+        output_path=output_path,
+        dataset_name="nv_pp_random",
+    )
+
+    assert resolve_generation_input(manifest_path) == output_path.resolve()
+
+
+def test_explicit_preparation_input_remains_authoritative(tmp_path: Path) -> None:
+    generated_output = _touch_jsonl(tmp_path / "stage0_sdg" / "generated.jsonl")
+    write_generation_manifest(
+        output_dir=generated_output.parent,
+        output_path=generated_output,
+        dataset_name="generated",
+    )
+    explicit_input = _touch_jsonl(tmp_path / "external" / "explicit.jsonl")
+
+    package_config = build_conversion_config(
+        DataPrepConfig(
+            artifact_root=tmp_path,
+            sdg_input_path=explicit_input,
+        )
+    )
+
+    assert package_config.input_path == explicit_input.resolve()
+
+
+def test_generation_manifest_rejects_missing_output(tmp_path: Path) -> None:
+    output_dir = tmp_path / "stage0_sdg"
+    with pytest.raises(FileNotFoundError, match="Generation output"):
+        write_generation_manifest(
+            output_dir=output_dir,
+            output_path=output_dir / "missing.jsonl",
+            dataset_name="missing",
+        )
+
+    assert not (output_dir / GENERATION_MANIFEST_FILENAME).exists()
+
+
+def test_generation_manifest_rejects_empty_dataset_name(tmp_path: Path) -> None:
+    output_dir = tmp_path / "stage0_sdg"
+    output_path = _touch_jsonl(output_dir / "generated.jsonl")
+
+    with pytest.raises(ValueError, match="dataset_name"):
+        write_generation_manifest(
+            output_dir=output_dir,
+            output_path=output_path,
+            dataset_name="",
+        )
+
+    assert not (output_dir / GENERATION_MANIFEST_FILENAME).exists()
+
+
+def test_default_manifest_filename_is_stable() -> None:
+    assert GENERATION_MANIFEST_FILENAME == "generation_result.json"
+
+
+def test_successful_generation_publishes_exact_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from nemotron.recipes.embed.stage0_sdg import plugin_adapter
+
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    (corpus_dir / "document.txt").write_text("retrieval content " * 10, encoding="utf-8")
+    output_path = _touch_jsonl(tmp_path / "stage0_sdg" / "resolved-name.jsonl")
+    result = SimpleNamespace(
+        output_path=output_path,
+        dataset_name="resolved-name",
+        num_records=1,
+        resolved_config_path=None,
+    )
+    monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
+    monkeypatch.setattr(plugin_adapter, "execute_generation", lambda *_args: result)
+
+    returned_path = run_sdg(
+        SDGConfig(
+            artifact_root=tmp_path,
+            corpus_dir=str(corpus_dir),
+            dataset_name="requested-name",
+        )
+    )
+
+    assert returned_path == output_path
+    assert resolve_generation_input(tmp_path / "stage0_sdg" / GENERATION_MANIFEST_FILENAME) == output_path.resolve()

--- a/tests/recipes/embed/test_shared_sdg_profiles.py
+++ b/tests/recipes/embed/test_shared_sdg_profiles.py
@@ -1,0 +1,47 @@
+"""Allium-derived contract tests for every shared retrieval SDG consumer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+pytest.importorskip("data_designer_retrieval_sdg")
+
+from nemo_runspec.config import load_config
+from nemotron.recipes.embed.stage0_sdg.data_prep import SDGConfig
+from nemotron.recipes.embed.stage0_sdg.plugin_adapter import build_generation_config
+from nemotron.recipes.embed.stage1_data_prep.data_prep import DataPrepConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROFILE_PATHS = [
+    REPO_ROOT / "src/nemotron/recipes/embed/stage0_sdg/config/default.yaml",
+    REPO_ROOT / "src/nemotron/recipes/embed/stage0_sdg/config/llama.yaml",
+    REPO_ROOT / "src/nemotron/recipes/rerank/stage0_sdg/config/default.yaml",
+]
+
+
+@pytest.mark.parametrize("profile_path", PROFILE_PATHS, ids=lambda path: str(path.parent.parent.parent))
+def test_shared_generation_profile_builds_released_package_config(
+    profile_path: Path,
+    tmp_path: Path,
+) -> None:
+    raw_config = OmegaConf.to_container(load_config(profile_path), resolve=True)
+    raw_config.pop("run", None)
+
+    recipe_config = SDGConfig.model_validate(raw_config)
+    package_config, _ = build_generation_config(recipe_config, tmp_path)
+
+    assert package_config.pipeline.num_pairs == sum(package_config.pipeline.query_counts.values())
+    assert package_config.pipeline.num_pairs == sum(package_config.pipeline.reasoning_counts.values())
+
+
+def test_rerank_preparation_profile_uses_exact_generation_handoff() -> None:
+    profile_path = REPO_ROOT / "src/nemotron/recipes/rerank/stage1_prep/config/default.yaml"
+    raw_config = OmegaConf.to_container(load_config(profile_path), resolve=True)
+    raw_config.pop("run", None)
+
+    recipe_config = DataPrepConfig.model_validate(raw_config)
+
+    assert recipe_config.sdg_input_path.name == "generation_result.json"


### PR DESCRIPTION
## Summary

- migrate the rerank SDG profile to the released retrieval plugin schema and validate every shared consumer profile
- publish an atomic `generation_result.json` handoff after successful Stage 0 runs
- make Stage 1 resolve the exact output from the latest successful run while preserving explicit input paths
- document and test first-run, repeated fresh-run, resumed-run, explicit-input, and invalid-output behavior

## Why

PR #326 delegates dataset naming and collision handling to Data Designer. Stage 0 can therefore choose a different output filename, especially when a repeated `resume=never` run creates a timestamped dataset. Stage 1 still assumed a fixed filename (or, for rerank, an output directory), so it could select old data or fail to find the new output.

The rerank Stage 0 profile also retained removed manual-batching fields and inconsistent pair-count defaults.

## How the Stage 0 to Stage 1 handoff works

Stage 0 continues to write the generated training records as JSON Lines (JSONL), for example:

```text
nv_pp_random_20260818_103000.jsonl
```

After the run succeeds, Stage 0 also writes a small metadata file:

```text
generation_result.json
```

That file records the exact JSONL output selected by Data Designer:

```json
{
  "schema_version": 1,
  "dataset_name": "nv_pp_random_20260818_103000",
  "output_path": "nv_pp_random_20260818_103000.jsonl"
}
```

The different extensions are intentional: the `.jsonl` file contains many generated records, one per line, while `generation_result.json` contains one JSON object that points to the dataset. Stage 1 reads this manifest by default, so it always prepares the output from the latest successful Stage 0 run. An explicit `sdg_input_path` still selects the caller-provided file or directory.

## Validation

- Allium contract check and analysis: no findings
- focused retrieval integration contract suite: 64 passed
- CPU embed/rerank recipe suite: 295 passed, 69 deselected
- data-format integration suite: 45 passed
- affected `uv.lock` files: checked
- Ruff lint and format: clean
- `git diff --check`: clean

Stacked on #326; intended to merge into Steve’s branch before the parent PR lands.