### PR TITLE
Fix Nemotron Lightning 3.5 VDR

### DIFF
--- a/usage-cookbook/Nemotron-3.5-Lightning/RL/README.md
+++ b/usage-cookbook/Nemotron-3.5-Lightning/RL/README.md
@@ -30,6 +30,8 @@ Run the commands in this root README from the login/head node, outside a Slurm
 allocation. The detailed workflow guides contain the allocation and driver
 commands.
 
+Note on prebuilt NGC container: Nemotron-3.5-Lightning requires a NemoRL container later than [v0.7](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/nemo-rl/-/tags) which is not yet available at the time of the model release data. Follow the docker build section below to build a container from source.
+
 ## Hardware Requirements
 
 The recipes in this directory target one DGX H100 node (eight H100 GPUs)
@@ -72,20 +74,24 @@ this from a node that support docker build:
 
 ```bash
 cd "${NEMO_RL}"
+export NEMO_RL_REV="$(git rev-parse --short=12 HEAD)"
 
 docker buildx build \
   --progress=plain \
   --build-context nemo-rl=. \
   -f docker/Dockerfile \
   --target release \
+  --build-arg MAX_JOBS=8 \
   --build-arg SKIP_SGLANG_BUILD=1 \
   --build-arg SKIP_TRTLLM_BUILD=1 \
-  -t nemo-rl:nemotron-3.5-lightning \
+  -t "nemo-rl:nemotron-3.5-lightning-${NEMO_RL_REV}" \
   .
 ```
 
+Note: this process can takes up to ~45 mins on a DGX H100 server.
+
 Use the container format and Slurm integration required by your site when
-following the detailed workflow guides. This might entail pushing the image to a central Docker registry.
+following the detailed workflow guides. This might entail pushing the image to a central Docker registry, or create a local .sqsh file for the NemoRL Docker image on the shared file system.
 
 
 ## Install Hugging Face Tools
@@ -120,7 +126,7 @@ export MODEL_DIR="${SHARED_ROOT}/models/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF
 export HF_HOME="${SHARED_ROOT}/.cache/huggingface"
 
 mkdir -p "${MODEL_DIR}" "${HF_HOME}"
-hf download nvidia/Nemotron-3.5-Lightning-30B-A3B-BF16 \
+hf download nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16 \
   --local-dir "${MODEL_DIR}"
 ```
 
@@ -139,3 +145,18 @@ for the NeMo Gym path.
 
 The recipes use 160 training steps, checkpoints every 10 steps,
 validates every 20 steps with 128 samples, and logs to W&B.
+
+## Historical dataset caveat
+
+The publisher's historical dataset-production framework produced repeated
+samples in the public artifacts: DAPO-Math-17k contains each source sample
+100 times, and AIME-2024 contains each source sample 32 times. These recipes
+deliberately do **not** filter or
+deduplicate either dataset; they consume the publisher-provided rows as-is.
+
+Treat training-row counts as repeated sampling rather than unique-problem
+counts. Likewise, repeated AIME rows are not independent validation examples,
+so do not interpret the configured validation sample count as an equally sized
+set of distinct problems. Deduplicate upstream if a unique-problem training or
+evaluation protocol is required, and record the resulting dataset revision,
+row count, and procedure with the run.

--- a/usage-cookbook/Nemotron-3.5-Lightning/RL/grpo-dapo-nemo-gym/grpo_training_cookbook_nemo_gym.md
+++ b/usage-cookbook/Nemotron-3.5-Lightning/RL/grpo-dapo-nemo-gym/grpo_training_cookbook_nemo_gym.md
@@ -5,7 +5,9 @@ for rollout routing and `math_with_judge` reward verification. Use an attached
 interactive NeMo RL allocation for data preparation and a one-step validation,
 then submit the full training run through NeMo RL's `ray.sub` batch workflow.
 
-Complete the public setup in [`../README.md`](../README.md) first.
+Complete the common setup in [`../README.md`](../README.md) first.
+
+Note on prebuilt NGC container: Nemotron-3.5-Lightning requires a NemoRL container later than [v0.7](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/nemo-rl/-/tags) which is not yet available at the time of the model release data. Follow the docker build section in [../README.md](../README.md) to build a container from source.
 
 ## Dataset and training goal
 
@@ -16,6 +18,31 @@ Gym routes them to the `math_with_judge` environment, where the verifiable math
 reward scores them before DAPO/GRPO updates the policy. The goal is to improve
 verifiable mathematical reasoning while exercising NeMo Gym's HTTP rollout and
 reward-routing integration on the tested single DGX H100 node topology.
+
+> **Historical dataset caveat:** the publisher's public artifacts repeat
+> DAPO-Math-17k samples 100 times and AIME-2024 samples 32 times. This
+> cookbook does not filter either dataset during
+> conversion. See [`../README.md`](../README.md#historical-dataset-caveat) for
+> the potential training and validation impact.
+
+## Required layout
+
+Mount your shared-storage root at `/shared` in the NeMo RL container. The
+direct recipe uses this layout:
+
+```text
+/shared                         <- Mount point for </YOUR/SHARED/STORAGE>
+|____code
+|    |____RL                    <- NeMo RL root repository
+|    |____Nemotron              <- Public repository containing this cookbook
+|____models
+|    |____NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+|____runs
+|____.cache/huggingface
+```
+
+Set the shared paths in your login/head-node shell before following the rest
+of this guide.
 
 ## Assets
 

--- a/usage-cookbook/Nemotron-3.5-Lightning/RL/grpo-dapo/grpo_training_cookbook.md
+++ b/usage-cookbook/Nemotron-3.5-Lightning/RL/grpo-dapo/grpo_training_cookbook.md
@@ -12,6 +12,8 @@ uses DAPOMath17K for training plus DAPOMathAIME2024 for validation. Complete
 the container, model, and shared-storage setup in [`../README.md`](../README.md)
 first.
 
+Note on prebuilt NGC container: Nemotron-3.5-Lightning requires a NemoRL container later than [v0.7](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/nemo-rl/-/tags) which is not yet available at the time of the model release data. Follow the docker build section in [../README.md](../README.md) to build a container from source.
+
 ## Dataset and training goal
 
 The policy learns from the public `BytedTsinghua-SIA/DAPO-Math-17k` math
@@ -21,6 +23,12 @@ updates the policy with DAPO/GRPO. Validation uses the held-out
 `BytedTsinghua-SIA/AIME-2024` problems. The goal is to improve reliably
 verifiable mathematical reasoning while keeping rollout, policy, and
 distributed-training behavior stable on one DGX H100 node.
+
+> **Historical dataset caveat:** the publisher's public artifacts repeat
+> DAPO-Math-17k samples 100 times and AIME-2024 samples 32 times. This
+> cookbook does not filter either dataset. See
+> [`../README.md`](../README.md#historical-dataset-caveat) for the potential
+> training and validation impact.
 
 ## Required layout
 
@@ -33,6 +41,7 @@ direct recipe uses this layout:
 |    |____RL                    <- NeMo RL root repository
 |    |____Nemotron              <- Public repository containing this cookbook
 |____models
+|    |____NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
 |____runs
 |____.cache/huggingface
 ```


### PR DESCRIPTION
## Description
Fix RL cookbooks after Nemotron Lightning 3.5 VDR report

- Add explicit requirement re. docker image being built from source, or a public image newer than v0.7 (which is not yet available)
- Clarify mount point and directory structure requirements. 
- Add notes re. duplicate data entries (historic limitation from data publisher)