### PR TITLE
Add GRPO recipe for Lightning on 2x Stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A complete training recipe for the 30B-A3B hybrid Mamba-Transformer MoE with Mul
 - [Release Blog](https://developer.nvidia.com/blog/nvidia-nemotron-3-5-lightning-delivers-fast-accurate-specialized-task-execution-for-long-running-agents/)
 - [Training Guide](docs/nemotron/lightning35/README.md)
 - [NeMo-RL Lightning Guide](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/guides/nemotron-3.5-lightning.md)
+- [Two-DGX Station GRPO Post-Training Guide](./usage-cookbook/Nemotron-3.5-Lightning/dgx-station-recipes/README.md)
 - [Quantization Guide (PTQ + QAD)](docs/nemotron/lightning35/quantization.md)
 - [Model Weights (Base)](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Base-BF16)
 - [Model Weights (Instruct)](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16)

--- a/docs/nemotron/lightning35/README.md
+++ b/docs/nemotron/lightning35/README.md
@@ -104,6 +104,7 @@ $ uv run nemotron lightning35 pipe --run YOUR-CLUSTER
 - **Training Datasets:**
   - [Pre-training Datasets](https://huggingface.co/collections/nvidia/nemotron-pre-training-datasets) (Open pre-training data)
   - [Post-training Datasets](https://huggingface.co/collections/nvidia/nemotron-post-training-v3) (SFT and RL data)
+- **Workstation Customization:** [Full-weight GRPO post-training on two DGX Station GB300 systems](https://github.com/NVIDIA-NeMo/Nemotron/blob/main/usage-cookbook/Nemotron-3.5-Lightning/dgx-station-recipes/README.md)
 
 <!-- TODO - move whatever customization docs for Lightning 3.5 to this section of the docs.
 ```{seealso}

--- a/usage-cookbook/Nemotron-3.5-Lightning/README.md
+++ b/usage-cookbook/Nemotron-3.5-Lightning/README.md
@@ -20,6 +20,7 @@ structured tool calling.
 
 ### Fine-Tuning
 
+- **[Two-DGX Station GRPO post-training](dgx-station-recipes/README.md)** - End-to-end full-weight Nemotron 3.5 Lightning customization on two DGX Station GB300 systems with NeMo RL, Ray, and NeMo Gym.
 - **[RL](https://github.com/NVIDIA-NeMo/Nemotron/blob/main/usage-cookbook/Nemotron-3.5-Lightning/RL/README.md)** - DAPO/GRPO RL training with NeMo RL, including native math-environment and NeMo Gym variants.
 - **[lora-text2sql/nemo-megatron-bridge](https://github.com/NVIDIA-NeMo/Nemotron/blob/main/usage-cookbook/Nemotron-3.5-Lightning/lora-text2sql/nemo-megatron-bridge/README.md)** - LoRA fine-tuning recipe for Text2SQL using NeMo Megatron-Bridge.
 

--- a/usage-cookbook/Nemotron-3.5-Lightning/RL/README.md
+++ b/usage-cookbook/Nemotron-3.5-Lightning/RL/README.md
@@ -8,6 +8,11 @@ This directory contains NeMo RL training guides for
 - `grpo-dapo-nemo-gym/`: DAPO/GRPO training that routes rollout and reward
   handling through [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym).
 
+For a non-Slurm, two-node workstation path, use the
+[two-DGX Station GRPO post-training guide](../dgx-station-recipes/README.md).
+It starts Ray directly in the NeMo RL containers and includes optional NFS,
+ARC-AGI data preparation, a two-GPU configuration, and a smoke test.
+
 The recipes assume a shared filesystem mounted into the training container at
 `/shared`, following the convention used in the Nemotron RL cookbooks:
 
@@ -27,9 +32,12 @@ commands.
 
 ## Hardware Requirements
 
-The supported Lightning configuration was tested on one DGX H100 node (eight
-H100 GPUs) managed by Slurm, with a shared filesystem visible from every node
-and mounted at `/shared` in the container, and an accessible Docker registry per your Slurm setup.
+The recipes in this directory target one DGX H100 node (eight H100 GPUs)
+managed by Slurm, with a shared filesystem visible from every node and mounted
+at `/shared` in the container, and an accessible Docker registry per your
+Slurm setup. The separate
+[DGX Station guide](../dgx-station-recipes/README.md) targets two DGX Station
+GB300 systems with one B300 GPU each.
 
 ## Clone the Repositories
 

--- a/usage-cookbook/Nemotron-3.5-Lightning/dgx-station-recipes/README.md
+++ b/usage-cookbook/Nemotron-3.5-Lightning/dgx-station-recipes/README.md
@@ -1,0 +1,650 @@
+# Customizing Nemotron 3.5 Lightning on Two DGX Stations with GRPO
+
+This guide runs full-weight GRPO post-training for
+[NVIDIA Nemotron 3.5 Lightning 30B-A3B BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16)
+on two DGX Station GB300 systems. It leverages the B300 GPU from each Station, a
+two-node Ray cluster, NeMo RL, NeMo Gym, and the
+[`python_inductive`](https://huggingface.co/datasets/nvidia/Nemotron-RL-ARC-AGI-v1)
+split of the Nemotron RL ARC-AGI dataset to customize Nemotron 3.5 Lightning.
+
+> [!NOTE]
+> The instructions use one Station as the **head** and the other as the
+> **worker**. Keep those roles unchanged for the entire run. Commands marked
+> **both Stations** must be run separately on each system; commands marked
+> **head only** or **worker only** run on that system only.
+
+> [!IMPORTANT]
+> This recipe pins NeMo RL source commit
+> [`7fa6e55`](https://github.com/NVIDIA-NeMo/RL/commit/7fa6e55192530ff1346d670ce74f9c70cab8f75b)
+> from August 18, 2026. That commit adds fractional optimizer CPU offload. The
+> recipe also applies a separate Nemotron-H MoE refit fix and a local vLLM
+> memory patch. Do not substitute a newer `main` revision without revalidating
+> the configuration and both patches.
+
+## What this recipe does
+
+| Component | Configuration |
+| --- | --- |
+| Hardware | Two DGX Station GB300 systems [connected via InfiniBand](https://build.nvidia.com/station/connect-two-stations/overview) |
+| Training | Full-weight synchronous GRPO with Megatron Core |
+| Parallelism | Expert parallel size 2 across the two GPUs |
+| Generation | Colocated vLLM, one tensor-parallel rank per GPU |
+| Memory strategy | Activation checkpointing and 75% optimizer-state CPU offload |
+| Sequence length | 16,536 tokens
+| Environment | NeMo Gym's `nvarc` Python-inductive ARC-AGI verifier |
+| Dataset | `python_inductive` split of [Nemotron-RL-ARC-AGI-v1](https://huggingface.co/datasets/nvidia/Nemotron-RL-ARC-AGI-v1) |
+
+This is provided as a recipe to showcase customization of Nemotron models using DGX Stations, not a reproduction of the model's complete post-training program or published evaluation results.
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- Two DGX Station GB300 systems with current DGX software, NVIDIA drivers,
+  Docker, and NVIDIA Container Toolkit. The
+  [DGX Station software stack](https://docs.nvidia.com/dgx/dgx-station-development-guide/porting/software-requirements.html)
+  includes these components.
+- The two Stations connected and validated for distributed GPU workloads.
+  Complete NVIDIA's
+  [Connect Two DGX Stations for Distributed Workloads](https://build.nvidia.com/station/connect-two-stations/overview)
+  playbook, including its RDMA/GPU-memory tests, before continuing.
+- A Linux user with `sudo` access on both Stations.
+- Internet access to `nvcr.io`, Hugging Face, GitHub, and, if enabled, Weights
+  & Biases.
+- Shared storage visible from both Stations at the same host path. The optional
+  NFS section below creates a simple demonstration share if one is not
+  available.
+
+Weights & Biases is enabled in the final configuration. You can either log in
+before the run or disable it with a command-line override shown later.
+
+## 1. Prepare both Stations
+
+### Enable non-root Docker access
+
+First, add non-root Docker access for your user if not already enabled.
+
+Run on **both Stations**:
+
+```bash
+sudo usermod -aG docker "${USER}"
+newgrp docker
+docker version
+```
+
+Membership in the `docker` group grants root-equivalent access to the host.
+
+### Verify the NVIDIA Drivers
+
+Verify the NVIDIA driver was installed correctly and your GPU is available:
+
+```bash
+nvidia-smi -L
+```
+
+The command should show a single B300 GPU in the list. If a display-only graphics card is included on the Station, that may also appear in the list.
+
+### Record the network values
+
+Run on **both Stations** to list the IPv4 addresses and Linux network-device
+names:
+
+```bash
+hostname
+ip -4 -br address show
+ip -4 route
+```
+
+Choose the high-speed interface used for traffic between the Stations. If you
+followed the two-Station networking playbook, map the `mlx5_0` HCA to its Linux
+network device with:
+
+```bash
+ibdev2netdev
+```
+
+`COMM_IFACE` must be the Linux network-device name (for example,
+`enP3s3f1np1`), not the HCA name `mlx5_0`. The final NeMo RL configuration is
+shared by both nodes, so this recipe assumes that the chosen Linux interface
+has the same name on both Stations.
+
+Record these values and export the same values in the host shell on **both
+Stations**:
+
+```bash
+export HEAD_IP=<HEAD_STATION_IPV4>
+export WORKER_IP=<WORKER_STATION_IPV4>
+export COMM_IFACE=<LINUX_NETWORK_INTERFACE>
+```
+
+Verify the path in both directions:
+
+```bash
+# Run on the head.
+ping -c 4 "${WORKER_IP}"
+
+# Run on the worker.
+ping -c 4 "${HEAD_IP}"
+```
+
+Do not continue until the pings and the prerequisite fabric tests succeed.
+The Stations must also permit trusted node-to-node traffic for Ray, NeMo Gym,
+NCCL, Gloo, and the configured port ranges.
+
+## 2. Configure shared storage
+
+If both Stations already mount shared storage at the same host path, export that path on **both Stations** and skip the remainder of this section:
+
+```bash
+export SHARED_HOST_PATH=<SHARED_STORAGE_HOST_PATH>
+```
+
+Verify that a file written from either Station appears on the other before
+launching the containers.
+
+### Optional: create an NFS export on the head
+
+If you do not already have a shared storage system on both Stations, the steps
+below will walk through installing and configuring an NFS server on the head
+node that will be shared between systems.
+
+The following setup is intentionally simple and is suitable for a trusted,
+point-to-point demonstration network. It is not a hardened or
+performance-tuned production storage design.
+
+Install and start the NFS server on the **head only**:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y nfs-kernel-server
+sudo systemctl enable --now nfs-kernel-server
+```
+
+Create the export directory:
+
+```bash
+sudo mkdir -p /mnt/nfs_share
+sudo chown -R "${USER}:$(id -gn)" /mnt/nfs_share
+sudo chmod 0777 /mnt/nfs_share
+```
+
+[!NOTE]
+> Mode `0777` allows root processes in a root-squashed containerized NFS client
+> to write this demonstration share. Restrict the client network as narrowly as
+> possible, and replace these permissions with your site's identity and storage
+> policy for anything beyond an isolated lab setup.
+
+Determine the network CIDR that contains both selected Station IPs. For a
+direct link this is commonly a `/30`, such as `192.168.240.0/30`. Export it on
+the **head only**:
+
+```bash
+export CLIENT_NETWORK_CIDR=<NETWORK_CIDR_FOR_BOTH_STATIONS>
+
+printf '/mnt/nfs_share %s(rw,sync,no_subtree_check)\n' \
+  "${CLIENT_NETWORK_CIDR}" \
+  | sudo tee /etc/exports.d/nemotron.exports
+
+sudo exportfs -ra
+sudo exportfs -v
+```
+
+Confirm that `/mnt/nfs_share` is listed before continuing.
+
+### Optional: mount the NFS export on both Stations
+
+Mount the newly-created NFS server on **both Stations**, including the head,
+so the container mount path is identical:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y nfs-common
+sudo mkdir -p /mnt/nfs
+sudo mount "${HEAD_IP}:/mnt/nfs_share" /mnt/nfs
+
+mountpoint /mnt/nfs
+df -hT /mnt/nfs
+export SHARED_HOST_PATH=/mnt/nfs
+```
+
+For a persistent mount, add an `_netdev` NFS entry to `/etc/fstab` according
+to your site's boot and network policy.
+
+## 3. Launch the NeMo RL container
+
+If your NGC organization requires authentication, log in on **both Stations**
+before pulling the image:
+
+```bash
+docker login nvcr.io
+```
+
+Use `$oauthtoken` as the username and an NGC API key as the password.
+
+Export the image and confirm all required values on **both Stations**:
+
+```bash
+export NEMO_RL_IMAGE=nvcr.io/nvidia/nemo-rl:v0.7.0
+
+printf 'HEAD_IP=%s\nWORKER_IP=%s\nCOMM_IFACE=%s\nSHARED_HOST_PATH=%s\n' \
+  "${HEAD_IP}" "${WORKER_IP}" "${COMM_IFACE}" "${SHARED_HOST_PATH}"
+
+test -d "${SHARED_HOST_PATH}"
+docker pull "${NEMO_RL_IMAGE}"
+```
+
+Start one container on **each Station**:
+
+```bash
+docker run -it \
+  --name nemo-rl \
+  --gpus all \
+  --network host \
+  --device=/dev/infiniband \
+  --shm-size=128g \
+  --ulimit nofile=65535:65535 \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  -e HEAD_IP="${HEAD_IP}" \
+  -e WORKER_IP="${WORKER_IP}" \
+  -e COMM_IFACE="${COMM_IFACE}" \
+  -e HF_HOME=/shared/.cache/huggingface \
+  -e NCCL_IB_HCA=mlx5_0,mlx5_1 \
+  -v "${SHARED_HOST_PATH}:/shared" \
+  "${NEMO_RL_IMAGE}"
+```
+
+`--device=/dev/infiniband` exposes the two CX8 RDMA devices to the container,
+and `NCCL_IB_HCA` selects both validated rails. If your site uses different HCA
+names, replace `mlx5_0,mlx5_1` with the names reported by `ibdev2netdev`.
+
+The rest of the guide runs inside these two container shells unless a step
+says otherwise. Keep both shells running for the duration of training. The
+containers are intentionally retained if a shell exits; re-enter one with:
+
+```bash
+docker start -ai nemo-rl
+```
+
+Inside both containers, verify the environment:
+
+```bash
+nvidia-smi -L
+df -hT /shared
+ulimit -Sn
+test -d /dev/infiniband
+ls -1 /dev/infiniband
+```
+
+A single B300 GPU should be visible in each container. The soft open-file limit
+should be `65535`, and `/shared` must resolve to the same storage from both
+containers. If `/dev/infiniband` is missing, NCCL will fall back to a slower
+socket transport or fail.
+
+## 4. Pin and patch NeMo RL
+
+In order to fit full-weight GRPO on two Stations, the optimizer's weights need
+to be partially offloaded to system memory to prevent CUDA OOM errors. This
+isn't available in the v0.7.0 NeMo-RL container but it can be patched from the
+upstream repository.
+
+The image contains the NeMo RL working tree at `/opt/nemo-rl`. The following
+changes are made inside each retained container, so repeat this entire section
+on **both Stations**.
+
+Update `uv` and check out the pinned source revision:
+
+```bash
+cd /opt/nemo-rl
+uv self update
+
+export NEMO_RL_BASE_COMMIT=7fa6e55192530ff1346d670ce74f9c70cab8f75b
+
+git fetch --no-recurse-submodules origin "${NEMO_RL_BASE_COMMIT}"
+git checkout -B dgx-station-lightning "${NEMO_RL_BASE_COMMIT}"
+git submodule sync --recursive
+git submodule update --init --recursive
+git --no-pager log -1 --oneline
+```
+
+The last command must start with `7fa6e55` and show
+`feat(megatron): support fractional optimizer CPU offload (#3628)`.
+Refreshing the submodules is required because this source revision pins newer
+NeMo Gym and Megatron components than the v0.7.0 container image.
+
+Configure an identity for the local cherry-pick, then apply the Nemotron-H MoE
+refit correction:
+
+```bash
+git config user.name "<YOUR_NAME>"
+git config user.email "<YOUR_EMAIL>"
+
+git fetch --no-recurse-submodules \
+  origin ruit/fix-nemotronh-moe-refit-shard-dim
+git cherry-pick 6bb55bc03adbdc4943fba5c9e452586c04afee88
+
+git --no-pager log -2 --oneline
+```
+
+The newest commit should be `fix(vllm): correct MoE refit shard_dim for
+grouped/3D experts (NemotronH)`.
+
+Patch async vLLM sleep to release the generation weights before policy
+training. The pinned source contains exactly one matching line:
+
+```bash
+export VLLM_ASYNC_WORKER=nemo_rl/models/generation/vllm/vllm_worker_async.py
+
+test "$(grep -c 'await self.llm.sleep(level=1)' "${VLLM_ASYNC_WORKER}")" -eq 1
+sed -i \
+  's/await self\.llm\.sleep(level=1)/await self.llm.sleep(level=2)/' \
+  "${VLLM_ASYNC_WORKER}"
+
+grep -n 'await self.llm.sleep' "${VLLM_ASYNC_WORKER}"
+git diff --check
+git status --short
+```
+
+The `grep` output must show `await self.llm.sleep(level=2)`. `git status`
+should show only `vllm_worker_async.py` as modified. If the pre-patch `test`
+fails, stop: the source revision is not the revision this recipe expects.
+
+Finally, ensure the active shell has the required limit:
+
+```bash
+ulimit -Sn 65535
+```
+
+## 5. Start the two-node Ray cluster
+
+NeMo-RL leverages Ray for serving the policy and inference engines and
+coordinating communication between the hosts. A Ray cluster needs to be started
+inside the containers for NeMo-RL to run in.
+
+### Start Ray on the head node
+
+Run inside the container on the **head only**:
+
+```bash
+cd /opt/nemo-rl
+uv run ray start \
+  --head \
+  --node-ip-address="${HEAD_IP}" \
+  --port=6379 \
+  --num-gpus=1
+
+ray status
+```
+
+At this point Ray should report one node and `1.0 GPU` total.
+
+### Join the Ray cluster on the worker
+
+Run inside the container on the **worker only**:
+
+```bash
+cd /opt/nemo-rl
+uv run ray stop --force
+uv run ray start \
+  --address="${HEAD_IP}:6379" \
+  --node-ip-address="${WORKER_IP}" \
+  --num-gpus=1
+
+ray status
+```
+
+The worker command must report a successful connection. Keep this container
+shell open.
+
+Back inside the container on the **head**, verify both nodes and both GPUs:
+
+```bash
+cd /opt/nemo-rl
+ray status
+```
+
+The output should indicate that two GPUs are available in the cluster:
+
+```bash
+...
+Resources
+---------------------------------------------------------------
+Total Usage:
+ 0.0/144.0 CPU
+ 0.0/2.0 GPU
+...
+```
+
+## 6. Authenticate and populate the shared cache
+
+To make training startup more efficient on both systems, pre-cache the
+Nemotron 3.5 Lightning model on the shared storage so it is available for both
+systems to pull from, avoiding a cold-pull to Hugging Face at the beginning of
+training.
+
+Run on the **head only**, inside the container:
+
+```bash
+mkdir -p /shared/.cache/huggingface
+export HF_HOME=/shared/.cache/huggingface
+hf auth login
+
+export MODEL_ID=nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+hf download "${MODEL_ID}"
+```
+
+The Hugging Face token and model cache are now available at the same path from
+both containers.
+
+If you want Weights and Biases (W&B) logging, authenticate on the **head only**:
+
+```bash
+wandb login
+```
+
+When prompted, enter your W&B API key to authenticate with their servers for
+the training process.
+
+## 7. Prepare the ARC-AGI dataset
+
+We will prepare the ARC-AGI dataset which includes several RL-focused data
+samples specializing in advanced mathematical operations.
+
+To prepare the dataset, run on the **head only** inside the container:
+
+```bash
+mkdir -p /shared/data
+cd /shared/data
+```
+
+Create `/shared/data/prep.py` with the following contents:
+
+```python
+from datasets import load_dataset
+
+
+dataset = load_dataset(
+    "nvidia/Nemotron-RL-ARC-AGI-v1",
+    "python_inductive",
+)
+
+dataset["train"].to_json("train.jsonl")
+dataset["validation"].to_json("validation.jsonl")
+dataset["train"].select(range(min(4, len(dataset["train"])))).to_json(
+    "smoke_train.jsonl"
+)
+```
+
+Run the converter and verify all three outputs:
+
+```bash
+python3 prep.py
+wc -l train.jsonl validation.jsonl smoke_train.jsonl
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+for name in ("train.jsonl", "validation.jsonl", "smoke_train.jsonl"):
+    path = Path(name)
+    assert path.stat().st_size > 0, f"{name} is empty"
+    with path.open() as stream:
+        row = json.loads(stream.readline())
+    assert "responses_create_params" in row
+    assert row["agent_ref"]["name"] == "nvarc_inductive_simple_agent"
+
+print("ARC-AGI NeMo Gym JSONL files are ready.")
+PY
+```
+
+## 8. Create the two-Station GRPO configuration
+
+Copy the config file at [grpo_lightning35_station.yaml](grpo_lightning35_station.yaml) in this repository and
+save it on the **head node**  inside the container at
+`/opt/nemo-rl/examples/nemo_gym/grpo_lightning35_station.yaml`.
+
+## 9. Launch the full distributed run
+
+Launch the full training run on the **head node**:
+
+```bash
+cd /opt/nemo-rl
+
+NRL_FORCE_REBUILD_VENVS=true \
+uv run examples/nemo_gym/run_grpo_nemo_gym.py \
+  --config examples/nemo_gym/grpo_lightning35_station.yaml \
+  ++policy.megatron_cfg.env_vars.GLOO_SOCKET_IFNAME="${COMM_IFACE}" \
+  ++policy.megatron_cfg.env_vars.NCCL_SOCKET_IFNAME="${COMM_IFACE}"
+```
+
+To run without W&B, add this override before the two interface overrides:
+
+```text
+logger.wandb_enabled=false
+```
+
+The driver remains attached to the head terminal. Leave the worker container
+and Ray process running until training ends.
+
+## 10. Monitor artifacts and cluster health
+
+From another shell, enter the retained container on either Station and inspect
+Ray and GPU health:
+
+```bash
+docker exec -it nemo-rl bash
+cd /opt/nemo-rl
+uv run ray status
+nvidia-smi
+```
+
+Depending on which stage of the training process is currently active, you
+should see tens to a couple hundred of GiBs of GPU memory allocated and GPU
+activity near 100% utilization, indicating training is running.
+
+Inspect the shared storage for logs and checkpoints. These directories will
+become populated as training completes a few steps:
+
+```bash
+find /shared/logs -maxdepth 2 -type f | sort | tail -n 20
+find /shared/results/grpo -maxdepth 2 -type f | sort | tail -n 20
+df -h /shared
+```
+
+Monitor free storage throughout the run, especially if retaining all
+checkpoints.
+
+If you logged results to W&B, login to your account in a web browser and view
+the link to your latest run. In general for GRPO workloads, you will want to
+see your reward signal increase over time, indicating your policy is learning
+how to achieve more desirable responses for your specific environment.
+
+## 11. Stopping the run and cleaning up
+
+If you need to stop the run, connect to the terminal process where training
+is running and hit `Ctrl+C` and allow the process to shut down its actors.
+
+To stop the Ray cluster, run the following in **both containers**:
+
+```bash
+cd /opt/nemo-rl
+uv run ray stop --force
+exit
+```
+
+The containers remain available for inspection or restart. Remove them only
+when their local patches and logs are no longer needed:
+
+```bash
+docker rm nemo-rl
+```
+
+Training data, model cache, logs, and checkpoints under `/shared` are not
+removed with the container.
+
+## Troubleshooting
+
+### Ray reports only one GPU
+
+- Run `nvidia-smi -L` inside both containers.
+- Confirm that the worker used `--address="${HEAD_IP}:6379"` and printed a
+  successful connection.
+- Confirm that `HEAD_IP` and `WORKER_IP` belong to the selected
+  `COMM_IFACE` network.
+- Stop stale Ray processes on both nodes, restart the head, then rejoin the
+  worker.
+
+### NCCL or Gloo cannot connect
+
+- Confirm that `COMM_IFACE` is the Linux device name present on both Stations,
+  not `mlx5_0`.
+- Confirm that `/dev/infiniband` exists inside both containers and that
+  `NCCL_IB_HCA` names the HCAs reported by `ibdev2netdev`.
+- Re-run the two-direction ping and the NVIDIA two-Station fabric validation.
+- Check host firewall rules against the port table in the Ray section, and
+  confirm that no other process is using those ports.
+- For the next diagnostic run, export `NCCL_DEBUG=INFO` in both container
+  shells before starting Ray. A healthy RDMA run reports `NET/IB` and the
+  selected CX8 HCAs; `NET/Socket` indicates a TCP fallback.
+
+### CUDA runs out of memory during policy training
+
+- Confirm the config contains `optimizer_cpu_offload: true` and
+  `optimizer_offload_fraction: 0.75`.
+- Confirm `grep -n 'self.llm.sleep'` shows `level=2` in
+  `vllm_worker_async.py` on both Stations.
+- Confirm Ray advertises exactly one GPU per Station and stop other GPU
+  workloads.
+- Do not increase sequence length, rollout count, or vLLM memory utilization
+  until the baseline run succeeds.
+
+### vLLM fails during Nemotron-H MoE weight refit
+
+Run `git log -1 --format=%s` on both Stations and verify that the subject is
+`fix(vllm): correct MoE refit shard_dim for grouped/3D experts (NemotronH)`.
+That local commit was cherry-picked from `6bb55bc`. Recreate the pinned patch
+stack if either working tree differs.
+
+### `/shared` is read-only or differs between nodes
+
+- Compare `df -hT /shared` and a test file from both containers.
+- For the demonstration NFS setup, confirm `exportfs -v` on the head and
+  `mountpoint /mnt/nfs` on both hosts.
+- Resolve UID/GID, root-squash, and permissions through your storage
+  administrator rather than disabling security controls on a shared network.
+
+### A source patch no longer applies
+
+Do not work around it by blindly changing line numbers. Verify that the base
+commit is exactly `7fa6e55`, recreate the retained container if needed, and
+repeat the patch section. A different NeMo RL revision requires recipe
+revalidation.
+
+## References
+
+- [NeMo RL repository](https://github.com/NVIDIA-NeMo/RL)
+- [NeMo RL v0.7.0 documentation](https://docs.nvidia.com/nemo/rl/0.7.0/index.html)
+- [Nemotron 3.5 Lightning model card](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16)
+- [Nemotron RL ARC-AGI dataset card](https://huggingface.co/datasets/nvidia/Nemotron-RL-ARC-AGI-v1)
+- [DGX Station software stack](https://docs.nvidia.com/dgx/dgx-station-development-guide/porting/software-requirements.html)
+- [Connect Two DGX Stations for Distributed Workloads](https://build.nvidia.com/station/connect-two-stations/overview)

--- a/usage-cookbook/Nemotron-3.5-Lightning/dgx-station-recipes/grpo_lightning35_station.yaml
+++ b/usage-cookbook/Nemotron-3.5-Lightning/dgx-station-recipes/grpo_lightning35_station.yaml
@@ -1,0 +1,306 @@
+grpo:
+  num_prompts_per_step: 16
+  num_generations_per_prompt: 16
+  val_num_generations_per_prompt: 4
+  max_rollout_turns: 1
+  max_num_epochs: 1
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 5
+  val_start_at: -1
+  val_at_start: false
+  val_at_end: false
+  overlong_filtering: true
+  advantage_clip_low: null
+  advantage_clip_high: null
+  max_val_samples: null
+  stop_at_validation_metric: null
+  stop_at_validation_threshold: null
+  val_batch_size: 256
+  seed: 42
+  async_grpo:
+    enabled: false
+    max_trajectory_age_steps: 1
+    max_generation_failures: 0
+
+  batch_multiplier: 1
+  use_dynamic_sampling: false
+  reward_shaping:
+    enabled: false
+  reward_scaling:
+    enabled: false
+
+  seq_logprob_error_threshold: 2
+  invalid_tool_call_advantage: null
+  malformed_thinking_advantage: null
+
+loss_fn:
+  reference_policy_kl_penalty: 0
+  reference_policy_kl_type: k3
+  kl_input_clamp_value: null
+  kl_output_clamp_value: null
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.28
+  ratio_clip_c: null
+  use_on_policy_kl_approximation: true
+  use_importance_sampling_correction: true
+  sequence_level_importance_ratios: false
+  token_level_loss: true
+  truncated_importance_sampling_ratio: null
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "/shared/results/grpo"
+  metric_name: "val:total_reward/mean"
+  higher_is_better: true
+  keep_top_k: 1000000
+  save_period: 10
+  checkpoint_must_save_by: "99:03:40:00"
+  save_optimizer: true
+
+policy:
+  model_name: "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+  tokenizer:
+    name: ${policy.model_name}
+  train_global_batch_size: 256
+  train_micro_batch_size: 1
+  generation_batch_size: 64
+  logprob_batch_size: 1
+  max_total_sequence_length: 16384
+  precision: "bfloat16"
+  logprob_chunk_size: 2048
+
+  dtensor_cfg:
+    _v2: true
+    enabled: false
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+
+  megatron_cfg:
+    enabled: true
+    checkpoint:
+      async_save: true
+    empty_unused_memory_level: 1
+    activation_checkpointing: true
+    bias_activation_fusion: false
+    tensor_model_parallel_size: 1
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 2
+    pipeline_model_parallel_size: 1
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    context_parallel_size: 1
+    pipeline_dtype: ${policy.precision}
+    sequence_parallel: true
+    freeze_moe_router: true
+    moe_router_dtype: "fp32"
+    moe_router_load_balancing_type: "none"
+    moe_router_bias_update_rate: 1e-3
+    moe_permute_fusion: true
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "alltoall"
+    moe_aux_loss_coeff: 0.0
+    moe_router_enable_expert_bias: true
+    apply_rope_fusion: true
+    defer_fp32_logits: true
+    track_moe_metrics: true
+    moe_per_layer_logging: true
+    moe_shared_expert_overlap: false
+    gradient_accumulation_fusion: false
+    use_fused_weighted_squared_relu: false
+    env_vars:
+      NCCL_SHM_DISABLE: "1"
+
+    optimizer:
+      optimizer: "adam"
+      lr: 3e-6
+      min_lr: 3e-6
+      weight_decay: 0.0
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1e-8
+      sgd_momentum: 0.9
+      clip_grad: ${policy.max_grad_norm}
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+      optimizer_cpu_offload: true
+      optimizer_offload_fraction: 0.75
+      overlap_cpu_optimizer_d2h_h2d: false
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: null
+      lr_warmup_iters: 10
+      lr_warmup_init: 3.0e-7
+
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      average_in_collective: false
+      use_custom_fsdp: false
+      data_parallel_sharding_strategy: "optim_grads_params"
+
+  draft:
+    enabled: false
+    model_name: null
+    loss_weight: 0.1
+    num_layers: null
+    aux_layer_indices: null
+
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: true
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    microbatch_order: "largest_first"
+    sequence_length_round: 64
+
+  make_sequence_length_divisible_by: ${mul:${mul:${policy.megatron_cfg.tensor_model_parallel_size}, ${policy.megatron_cfg.context_parallel_size}}, 2}
+  max_grad_norm: 1.0
+  optimizer: null
+  scheduler: null
+  offload_optimizer_for_logprob: false
+
+  generation:
+    port_range_low: 11001
+    port_range_high: 15000
+    backend: "vllm"
+    max_new_tokens: ${policy.max_total_sequence_length}
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    val_temperature: ${.temperature}
+    val_top_p: ${.top_p}
+    val_top_k: ${.top_k}
+    stop_token_ids: null
+    stop_strings: null
+    mcore_generation_config:
+      max_model_len: ${policy.max_total_sequence_length}
+      transformer_impl: "inference_optimized"
+      cuda_graph_impl: "local"
+      inference_cuda_graph_scope: "block"
+      activation_checkpointing: false
+      mamba_inference_ssm_states_dtype: "float32"
+      inference_moe_token_dispatcher_type: "nccl"
+      inference_grouped_gemm_backend: "vllm"
+      moe_router_num_groups: null
+      moe_router_group_topk: null
+      pipeline_model_parallel_size: 1
+      expert_tensor_parallel_size: 1
+      expert_model_parallel_size: 8
+      sequence_parallel: true
+      context_parallel_size: 1
+      tensor_model_parallel_size: 2
+      buffer_size_gb: 20
+      num_cuda_graphs: -1
+      block_size_tokens: 256
+      use_cuda_graphs_for_non_decode_steps: true
+      enable_chunked_prefill: true
+      max_tokens: 16384
+      kv_cache_management_mode: "persist"
+      materialize_only_last_token_logits: true
+      num_speculative_tokens: 0
+      refit_backend: "nccl"
+      expose_http_server: true
+      enable_prefix_caching: true
+      parsers:
+        - deepseek-r1-reasoning
+        - qwen3-coder-tool
+    vllm_cfg:
+      async_engine: true
+      kv_cache_dtype: auto
+      precision: ${policy.precision}
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      gpu_memory_utilization: 0.60
+      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: false
+      use_deep_gemm: false
+      num_last_layers_in_bf16: 0
+      num_first_layers_in_bf16: 0
+      expose_http_server: true
+      reasoning_parser_plugin: nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py
+      http_server_serving_chat_kwargs:
+        enable_auto_tools: true
+        tool_parser: qwen3_coder
+        reasoning_parser: nano_v3
+
+    vllm_kwargs:
+      mamba_ssm_cache_dtype: "float32"
+      moe_backend: triton
+      compilation_config:
+        backend: eager
+    colocated:
+      enabled: true
+      resources:
+        gpus_per_node: null
+        num_nodes: null
+
+data:
+  max_input_seq_length: null
+  shuffle: false
+  num_workers: 1
+  use_multiple_dataloader: false
+  train:
+    data_path: "/shared/data/train.jsonl"
+  validation:
+    data_path: "/shared/data/validation.jsonl"
+  default:
+    dataset_name: NemoGymDataset
+    env_name: "nemo_gym"
+    prompt_file: null
+    system_prompt_file: null
+    processor: "nemo_gym_data_processor"
+
+env:
+  should_use_nemo_gym: true
+  should_log_nemo_gym_responses: true
+  should_mask_flagged_samples: true
+  nemo_gym:
+    port_range_low: 15001
+    port_range_high: 20000
+    config_paths:
+      - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+      - resources_servers/nvarc/configs/inductive.yaml
+
+logger:
+  log_dir: "/shared/logs"
+  num_val_samples_to_print: 0
+  wandb_enabled: true
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  monitor_gpus: true
+  swanlab_enabled: false
+  wandb:
+    project: "nemotron-station"
+    name: "lightning-grpo"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "grpo-dev"
+    run_name: "grpo-dev-logger"
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+cluster:
+  gpus_per_node: 1
+  num_nodes: 2

--- a/usage-cookbook/README.md
+++ b/usage-cookbook/README.md
@@ -13,4 +13,5 @@ This directory contains cookbook-style guides showing how to deploy and use the 
 - **SGLang Deployment** - Tutorials on serving and interacting with Nemotron via SGLang
 - **NIM Microservice** - Guide to deploying Nemotron as scalable, production-ready endpoints using NVIDIA Inference Microservices (NIM).
 - **Hugging Face Transformers** - Direct loading and inference of Nemotron models with Hugging Face Transformers
+- **DGX Station Post-Training** - [Customize Nemotron 3.5 Lightning with full-weight GRPO on two DGX Station GB300 systems](Nemotron-3.5-Lightning/dgx-station-recipes/README.md).
 - **OCI OKE Private Deployment** - A Phoenix-only private deployment guide for `nvidia/Llama-3.1-Nemotron-Nano-8B-v1` using OKE, OCI Bastion service, and `vLLM`, providing a reproducible OCI path comparable to common AWS GPU/Kubernetes deployment patterns.


### PR DESCRIPTION
## Description

Added a new DGX Station section for the Nemotron 3.5 Lightning recipes targeting full-weight GRPO. The recipe is optimized for GRPO on two Stations with a single B300 GPU, each at 16k sequence length.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement
- [x] New training recipe or step

## Changes Made

- Added new recipe for GRPO on Nemotron 3.5 Lightning using NeMo-RL on 2x DGX Stations

## Testing

N/A

## Checklist

- [x] My code follows the existing style conventions (ruff + ruff-format)
- [x] I have added type hints and docstrings where applicable
- [x] I have added tests for new functionality
- [x] All existing and new tests pass
- [x] I have updated documentation where needed
- [x] My commits are signed off (`git commit -s`) per the DCO